### PR TITLE
docs: fix metera typos

### DIFF
--- a/developer-guide/invent/actions/metsumi-actions.mdx
+++ b/developer-guide/invent/actions/metsumi-actions.mdx
@@ -28,7 +28,7 @@ npm install -g pnpm
     Meteora Invent is a toolkit consisting of everything you need to invent innovative token launches on Meteora. Run the following command in your terminal to get started.
 
     ```bash Terminal
-    git clone https://github.com/MeteoraAg/metera-invent.git
+    git clone https://github.com/MeteoraAg/meteora-invent.git
     ```
 
     Once you've cloned the repository, you'll have a new project directory with a meteora-invent folder. Run the following to install pnpm and the project dependencies. 

--- a/developer-guide/invent/scaffolds/fun-launch.mdx
+++ b/developer-guide/invent/scaffolds/fun-launch.mdx
@@ -68,7 +68,7 @@ In this guide, Metsumi will walk you through the steps to create a launchpad pla
     Meteora Invent is a toolkit consisting of everything you need to invent innovative token launches on Meteora. Run the following command in your terminal to get started.
 
     ```bash Terminal
-    git clone https://github.com/MeteoraAg/metera-invent.git
+    git clone https://github.com/MeteoraAg/meteora-invent.git
     ```
 
     Once you've cloned the repository, you'll have a new project directory with a meteora-invent folder. Run the following to install pnpm and the project dependencies. 

--- a/developer-guide/quick-launch/damm-v1-launch-pool.mdx
+++ b/developer-guide/quick-launch/damm-v1-launch-pool.mdx
@@ -41,7 +41,7 @@ npm install -g pnpm
   Meteora Invent is a toolkit consisting of everything you need to invent innovative token launches on Meteora. Run the following command in your terminal to get started.
 
   ```bash Terminal
-  git clone https://github.com/MeteoraAg/metera-invent.git
+  git clone https://github.com/MeteoraAg/meteora-invent.git
   ```
 
   Once you've cloned the repository, you'll have a new project directory with a meteora-invent folder. Run the following to install pnpm and the project dependencies. 

--- a/developer-guide/quick-launch/damm-v2-launch-pool.mdx
+++ b/developer-guide/quick-launch/damm-v2-launch-pool.mdx
@@ -42,7 +42,7 @@ npm install -g pnpm
   Meteora Invent is a toolkit consisting of everything you need to invent innovative token launches on Meteora. Run the following command in your terminal to get started.
 
   ```bash Terminal
-  git clone https://github.com/MeteoraAg/metera-invent.git
+  git clone https://github.com/MeteoraAg/meteora-invent.git
   ```
 
   Once you've cloned the repository, you'll have a new project directory with a meteora-invent folder. Run the following to install pnpm and the project dependencies. 

--- a/developer-guide/quick-launch/dbc-token-launch-pool.mdx
+++ b/developer-guide/quick-launch/dbc-token-launch-pool.mdx
@@ -42,7 +42,7 @@ npm install -g pnpm
   Meteora Invent is a toolkit consisting of everything you need to invent innovative token launches on Meteora. Run the following command in your terminal to get started.
 
   ```bash Terminal
-  git clone https://github.com/MeteoraAg/metera-invent.git
+  git clone https://github.com/MeteoraAg/meteora-invent.git
   ```
 
   Once you've cloned the repository, you'll have a new project directory with a meteora-invent folder. Run the following to install pnpm and the project dependencies. 

--- a/developer-guide/quick-launch/dlmm-launch-pool.mdx
+++ b/developer-guide/quick-launch/dlmm-launch-pool.mdx
@@ -41,7 +41,7 @@ npm install -g pnpm
   Meteora Invent is a toolkit consisting of everything you need to invent innovative token launches on Meteora. Run the following command in your terminal to get started.
 
   ```bash Terminal
-  git clone https://github.com/MeteoraAg/metera-invent.git
+  git clone https://github.com/MeteoraAg/meteora-invent.git
   ```
 
   Once you've cloned the repository, you'll have a new project directory with a meteora-invent folder. Run the following to install pnpm and the project dependencies. 


### PR DESCRIPTION
Following the Meteora docs to create a new DLMM liquidity pool, was trying to clone the repo but failed. fixed URLs in documentation.