### PR TITLE
docs: revamp DAMM v2, DBC, and DLMM documentation

### DIFF
--- a/developer-guide/guides/damm-v2/overview.mdx
+++ b/developer-guide/guides/damm-v2/overview.mdx
@@ -77,17 +77,11 @@ DAMM v2 pools have a `layout_version` field that indicates the on-chain account 
 | 0 | Original layout. Does not track `token_a_amount` or `token_b_amount`. |
 | 1 | Tracks `token_a_amount` and `token_b_amount` directly in the pool state. |
 
-All new pools are created with `layout_version = 1`. Existing v0 pools can be migrated to v1 using the `fix_pool_layout_version` instruction.
+All new pools are created with `layout_version = 1`.
 
 <Note>
 When reading pool state, check `layout_version` before accessing `token_a_amount` or `token_b_amount`. These fields are only populated on v1 pools.
 </Note>
-
-## Operator Permission System
-
-DAMM v2 pools support a granular operator permission system with 12 discrete permissions. An operator account can be delegated a subset of these permissions by the pool creator, allowing third parties (such as market makers or bots) to manage specific pool parameters without holding full authority.
-
-Permissions cover operations such as updating fee parameters, activating or deactivating the pool, and modifying liquidity ranges. Refer to the DAMM v2 program source for the full list of permission flags.
 
 ## Compounding Fee Mode
 

--- a/developer-guide/guides/damm-v2/overview.mdx
+++ b/developer-guide/guides/damm-v2/overview.mdx
@@ -68,6 +68,47 @@ At Meteora, we’ve developed a `Node.js <> Typescript SDK`, a `Rust SDK` and a 
   </table>
 </div>
 
+## Pool Layout Versioning
+
+DAMM v2 pools have a `layout_version` field that indicates the on-chain account layout version.
+
+| `layout_version` | Description |
+|---|---|
+| 0 | Original layout. Does not track `token_a_amount` or `token_b_amount`. |
+| 1 | Tracks `token_a_amount` and `token_b_amount` directly in the pool state. |
+
+All new pools are created with `layout_version = 1`. Existing v0 pools can be migrated to v1 using the `fix_pool_layout_version` instruction.
+
+<Note>
+When reading pool state, check `layout_version` before accessing `token_a_amount` or `token_b_amount`. These fields are only populated on v1 pools.
+</Note>
+
+## Operator Permission System
+
+DAMM v2 pools support a granular operator permission system with 12 discrete permissions. An operator account can be delegated a subset of these permissions by the pool creator, allowing third parties (such as market makers or bots) to manage specific pool parameters without holding full authority.
+
+Permissions cover operations such as updating fee parameters, activating or deactivating the pool, and modifying liquidity ranges. Refer to the DAMM v2 program source for the full list of permission flags.
+
+## Compounding Fee Mode
+
+DAMM v2 v0.2.0 introduces a third fee collection mode (`collect_fee_mode = 2`).
+
+| `collect_fee_mode` | Fee Token | Fee on Input? |
+|---|---|---|
+| 0 (BothToken) | Output token | No (fee on output) |
+| 1 (OnlyB) | Token B | Only for B→A trades |
+| 2 (Compounding) | Token B | Only for B→A trades |
+
+In Compounding mode, a percentage of the collected fee (set by `compounding_fee_bps` on the config) is automatically reinvested back into pool reserves rather than accruing to LP positions. This portion is reported as `compounding_fee` in `EvtSwap2`. The remaining claimable portion is reported as `claiming_fee`.
+
+<Note>
+Compounding mode pools use a constant-product formula with no concentrated liquidity range.
+</Note>
+
+<Warning>
+**Breaking change in v0.2.0:** The `partner` field has been removed from the Pool struct and the `claim_partner_fee` instruction has been removed. The `partner_fee` field in `EvtSwap2` has been replaced by `compounding_fee`. Integrations that previously read `partner_fee` must be updated.
+</Warning>
+
 ## Official SDKs
 
 <CardGroup cols={2}>

--- a/developer-guide/guides/damm-v2/overview.mdx
+++ b/developer-guide/guides/damm-v2/overview.mdx
@@ -68,21 +68,6 @@ At Meteora, we’ve developed a `Node.js <> Typescript SDK`, a `Rust SDK` and a 
   </table>
 </div>
 
-## Pool Layout Versioning
-
-DAMM v2 pools have a `layout_version` field that indicates the on-chain account layout version.
-
-| `layout_version` | Description |
-|---|---|
-| 0 | Original layout. Does not track `token_a_amount` or `token_b_amount`. |
-| 1 | Tracks `token_a_amount` and `token_b_amount` directly in the pool state. |
-
-All new pools are created with `layout_version = 1`.
-
-<Note>
-When reading pool state, check `layout_version` before accessing `token_a_amount` or `token_b_amount`. These fields are only populated on v1 pools.
-</Note>
-
 ## Compounding Fee Mode
 
 DAMM v2 v0.2.0 introduces a third fee collection mode (`collect_fee_mode = 2`).
@@ -98,10 +83,6 @@ In Compounding mode, a percentage of the collected fee (set by `compounding_fee_
 <Note>
 Compounding mode pools use a constant-product formula with no concentrated liquidity range.
 </Note>
-
-<Warning>
-**Breaking change in v0.2.0:** The `partner` field has been removed from the Pool struct and the `claim_partner_fee` instruction has been removed. The `partner_fee` field in `EvtSwap2` has been replaced by `compounding_fee`. Integrations that previously read `partner_fee` must be updated.
-</Warning>
 
 ## Official SDKs
 

--- a/developer-guide/guides/dbc/bonding-curve-configs.mdx
+++ b/developer-guide/guides/dbc/bonding-curve-configs.mdx
@@ -172,6 +172,10 @@ tokenSupply: {
 
 - The pool fees comprises of the `baseFee` and `dynamicFee`
 
+<Warning>
+**Minimum base fee is 25 bps (0.25%).** Configs with a base fee lower than 25 bps will be rejected by the program.
+</Warning>
+
 #### `baseFee`
 
 - The base fee is a struct the contains the following fields:
@@ -265,6 +269,8 @@ enableFirstSwapWithMinFee: true
 - If you want your pool to automatically migrate when the `poolState.quoteReserve` is greater than or equal to the `poolConfig.migrationQuoteThreshold`, you would need to set the `migrationQuoteThreshold` to have a minimum value of 750 USD. You can read more about our migration keepers [here](/developer-guide/guides/dbc/overview#migration-keeper)
 
 ### `migrationFee`
+
+<Note>The maximum `feePercentage` for migration fees is **99%**.</Note>
 
 - The `migrationFee` is the amount of quote token that you want to collect as fee when the token pool migrates from pre-graduation to post-graduation.
 - This `migrationFee` will be collected from the `migrationQuoteThreshold` amount of quote token.

--- a/developer-guide/guides/dbc/bonding-curve-configs.mdx
+++ b/developer-guide/guides/dbc/bonding-curve-configs.mdx
@@ -65,7 +65,7 @@ A typical DBC curve config will look like this when you parse it into the `creat
         creatorTradingFeePercentage: 0,
         tokenUpdateAuthority: 1,
         migrationFee: { feePercentage: 0, creatorFeePercentage: 0 },
-        migratedPoolFee: { collectFeeMode: 0, dynamicFee: 0, poolFeeBps: 0 },
+        migratedPoolFee: { collectFeeMode: 0, dynamicFee: 0, poolFeeBps: 0, compoundingFeeBps: 0 },
         poolCreationFee: new BN(0),
         enableFirstSwapWithMinFee: false,
         partnerLiquidityVestingInfo: {
@@ -329,8 +329,31 @@ migrationFee: {
     - `collectFeeMode` - The collect fee mode of the post-graduation pool.
     - `dynamicFee` - The dynamic fee of the post-graduation pool.
     - `poolFeeBps` - The pool fee of the post-graduation pool.
+    - `compoundingFeeBps` - The compounding fee rate in basis points. Must be non-zero when `collectFeeMode` is `2` (Compounding), and must be `0` for all other modes.
 
 <Note>When `marketCapFeeSchedulerParams` is configured, `poolFeeBps` must be greater than 0 as it serves as the starting (cliff) fee for the market cap fee scheduler.</Note>
+
+#### `migratedPoolFee.collectFeeMode` options
+
+Controls how trading fees are collected in the graduated DAMM v2 pool:
+
+- `0` (`QuoteToken`) — Fees are collected in the quote token only. Maps to DAMM v2's `OnlyB` mode.
+- `1` (`OutputToken`) — Fees are collected in the output token of each swap (both tokens). Maps to DAMM v2's `BothToken` mode.
+- `2` (`Compounding`) — Fees are automatically reinvested into the LP position. Requires `compoundingFeeBps` to be non-zero.
+
+Example — Compounding fee mode:
+```typescript
+migratedPoolFee: {
+    collectFeeMode: 2,       // Compounding
+    dynamicFee: 0,
+    poolFeeBps: 100,         // 1% base fee
+    compoundingFeeBps: 50    // 0.5% compounded back into LP
+}
+```
+
+<Warning>
+When `collectFeeMode` is set to `2` (Compounding), `compoundingFeeBps` must be greater than `0`. When using any other mode, `compoundingFeeBps` must be `0`.
+</Warning>
 
 ### `liquidityPercentage`
 

--- a/developer-guide/guides/dbc/overview.mdx
+++ b/developer-guide/guides/dbc/overview.mdx
@@ -84,6 +84,43 @@ At Meteora, we’ve developed a `Node.js <> Typescript SDK`, a `Rust SDK` and a 
 
 ---
 
+# Operator Account System
+
+The Operator Account System provides a flexible, permission-based way for admins to delegate protocol fee management to whitelisted addresses.
+
+<Note>Operator accounts replace the previous `create_claim_protocol_fee_operator` approach. They are created by the program admin only.</Note>
+
+## Instructions
+
+- `create_operator_account(permission: u128)` — Creates an operator account for a whitelisted address with a bitmask of permissions.
+- `close_operator_account()` — Removes an existing operator account.
+
+## Permissions
+
+Permissions are encoded as a `u128` bitmask. Multiple permissions can be combined.
+
+| Permission | Bit | Description |
+|---|---|---|
+| `ClaimProtocolFee` | 0 | Can claim protocol fees and pool creation fees |
+| `ZapProtocolFee` | 1 | Can zap protocol fees into SOL/USDC or pool tokens |
+
+## PDA
+
+Operator accounts are PDAs derived from:
+```
+[OPERATOR_PREFIX, whitelisted_address]
+```
+
+## `zap_protocol_fee`
+
+Operators with the `ZapProtocolFee` permission can call `zap_protocol_fee` to convert accumulated protocol fees from any token into SOL, USDC, or pool tokens.
+
+<Warning>SOL and USDC protocol fees cannot be zapped — they must be claimed directly via `claim_protocol_fee`.</Warning>
+
+<Note>`zap_protocol_fee` requires the `SYSVAR_INSTRUCTIONS_PUBKEY` sysvar account to be included for transaction context validation.</Note>
+
+---
+
 # Migration
 
 DBC pools can be migrated to either a DAMM v1 or DAMM v2 pool. The DAMM v1 and DAMM v2 pools are both derived from the `baseMint`, `quoteMint` and `dammConfig`.
@@ -100,12 +137,14 @@ DBC pools can be migrated to either a DAMM v1 or DAMM v2 pool. The DAMM v1 and D
 
 #### Liquidity Vesting (DAMM V2 only)
 
-If `partnerLiquidityVestingInfoParams` or `creatorLiquidityVestingInfoParams` are configured, the migration will also create vesting accounts for the LP positions.
+If `partnerLiquidityVestingInfoParams` or `creatorLiquidityVestingInfoParams` are configured, vesting is handled directly via LP positions during migration. No separate `migration_metadata` account is required.
 
 #### DAMM V2
 
 1. `createLocker` (if the token has locked vesting)
 2. `migrateToDammV2`
+
+<Note>DAMM v2 migration now uses positions directly for vesting, removing the need for a separate `migration_metadata` account. This simplifies the migration flow and reduces the number of accounts and transactions required.</Note>
 
 ## DAMM Fee Config Keys
 

--- a/developer-guide/guides/dbc/overview.mdx
+++ b/developer-guide/guides/dbc/overview.mdx
@@ -84,40 +84,22 @@ At Meteora, we’ve developed a `Node.js <> Typescript SDK`, a `Rust SDK` and a 
 
 ---
 
-# Operator Account System
+# Swap Modes
 
-The Operator Account System provides a flexible, permission-based way for admins to delegate protocol fee management to whitelisted addresses.
+DBC supports two swap instructions:
 
-<Note>Operator accounts replace the previous `create_claim_protocol_fee_operator` approach. They are created by the program admin only.</Note>
+| Instruction | Modes |
+|---|---|
+| `swap` | ExactIn only |
+| `swap2` | ExactIn (0), PartialFill (1), ExactOut (2) |
 
-## Instructions
+`swap2` includes additional information in the `EvtSwap2` event such as `quoteReserveAmount`, `migrationThreshold`, and `includedFeeInputAmount`.
 
-- `create_operator_account(permission: u128)` — Creates an operator account for a whitelisted address with a bitmask of permissions.
-- `close_operator_account()` — Removes an existing operator account.
+<Note>For pools with Rate Limiter enabled (`baseFeeMode == 2`), the `SYSVAR_INSTRUCTIONS_PUBKEY` must be included in the remaining accounts of the swap instruction.</Note>
 
-## Permissions
+# Pool Creator Transfer
 
-Permissions are encoded as a `u128` bitmask. Multiple permissions can be combined.
-
-| Permission | Bit | Description |
-|---|---|---|
-| `ClaimProtocolFee` | 0 | Can claim protocol fees and pool creation fees |
-| `ZapProtocolFee` | 1 | Can zap protocol fees into SOL/USDC or pool tokens |
-
-## PDA
-
-Operator accounts are PDAs derived from:
-```
-[OPERATOR_PREFIX, whitelisted_address]
-```
-
-## `zap_protocol_fee`
-
-Operators with the `ZapProtocolFee` permission can call `zap_protocol_fee` to convert accumulated protocol fees from any token into SOL, USDC, or pool tokens.
-
-<Warning>SOL and USDC protocol fees cannot be zapped — they must be claimed directly via `claim_protocol_fee`.</Warning>
-
-<Note>`zap_protocol_fee` requires the `SYSVAR_INSTRUCTIONS_PUBKEY` sysvar account to be included for transaction context validation.</Note>
+Pool creators can transfer their creator rights to a new address using the `transfer_pool_creator` instruction. This transfers all creator privileges including fee claiming rights and surplus withdrawal.
 
 ---
 

--- a/developer-guide/guides/dlmm/overview.mdx
+++ b/developer-guide/guides/dlmm/overview.mdx
@@ -50,46 +50,80 @@ We also outline a list of unofficial community SDKs made by our wonderful commun
   </table>
 </div>
 
-## Operator Permission System
-
-DLMM v0.11.0 introduces an operator account system. An operator account can be created by an authorized party and delegated a subset of discrete permissions, allowing third parties (such as market makers or bots) to manage specific pool and program parameters without holding full authority.
-
-Supported permissions include:
-
-| Permission | Description |
-|---|---|
-| `InitializePermissionedPool` | Create a permissioned pool |
-| `InitializePresetParameter` | Create a preset bin step / fee parameter |
-| `ClaimProtocolFee` | Collect accrued protocol fees |
-| `ZapProtocolFee` | Zap collected protocol fees to a target token |
-| `InitializeReward` | Set up a farming reward on a pool |
-| `UpdateRewardFunder` | Change the reward funder address |
-| `UpdateRewardDuration` | Adjust reward distribution duration |
-| `UpdateFeeParameters` | Modify base fee and variable fee parameters |
-| `SetPairStatus` | Enable or disable swaps on a pool |
-| `InitializeTokenBadge` | Register a Token 2022 token badge |
-| `CloseTokenBadge` | Remove a token badge |
-| `ClosePresetParameter` | Remove a preset parameter account |
-| `ResetTombstoneFields` | Reset tombstone fields on a closed account |
-
-Operator accounts are managed via the `create_operator_account` and `close_operator_account` instructions.
-
-## Dynamic Positions
-
-DLMM v0.11.0 introduces `PositionV2`, which supports up to **1,400 bins** per position — a significant increase from the previous 70-bin limit. This is achieved through extended byte data attached to the position account, which is allocated on demand as the position grows.
-
-Positions can also be resized dynamically on both the lower and upper sides, allowing liquidity ranges to be expanded without closing and reopening positions.
-
 ## Pool Types
 
 DLMM supports four pool types:
 
 | Pool Type | Description |
 |---|---|
-| `Permissionless` | Standard open pool, no special requirements |
-| `PermissionlessV2` | Updated permissionless pool with extended capabilities |
-| `Permission` | Pool restricted to permissioned participants |
-| `CustomizablePermissionless` | Open pool with creator-controlled on/off switch and customizable fee parameters |
+| `Permissionless` | Standard open pool, no special requirements. |
+| `PermissionlessV2` | Latest pool type with Token 2022 support, extended config parameters, and `function_type` setting. Created via `initialize_lb_pair2`. |
+| `Permission` | Admin-controlled pool for token launches with activation point, pre-activation duration, and lock duration settings. |
+| `CustomizablePermissionless` | Open pool with creator-controlled on/off switch, customizable base fee, activation point, and Alpha Vault support. |
+
+<Note>`PermissionlessV2` pools no longer enforce SOL/USDC quote token constraints — any token pair is supported.</Note>
+
+## Function Type
+
+When creating a `PermissionlessV2` pool, a `function_type` parameter is required:
+
+| Function Type | Description |
+|---|---|
+| `LiquidityMining` (0) | Pool supports farming rewards via `initialize_reward`. |
+
+<Warning>The `initialize_reward` instruction only works on pools with `function_type = LiquidityMining`. Pools created without this function type cannot have farming rewards added later.</Warning>
+
+## Dynamic Positions
+
+DLMM supports `PositionV2`, which supports up to **1,400 bins** per position — a significant increase from the previous 70-bin limit. This is achieved through extended byte data attached to the position account, which is allocated on demand as the position grows.
+
+### Position Resize
+
+Positions can be resized dynamically without closing and reopening:
+
+| Instruction | Description |
+|---|---|
+| `increase_position_length` / `increase_position_length2` | Expand the position's bin range. |
+| `decrease_position_length` | Shrink the position from the lower or upper end. |
+
+### Rebalance Liquidity
+
+The `rebalance_liquidity` instruction allows position owners to combine multiple liquidity operations (add, remove, shift) and resize the position in a single instruction.
+
+It supports a `shrink_mode` parameter:
+
+| Shrink Mode | Description |
+|---|---|
+| `ShrinkBoth` | Shrink empty bins on both sides. |
+| `NoShrinkLeft` | Keep left (lower) bins, shrink right only. |
+| `NoShrinkRight` | Keep right (upper) bins, shrink left only. |
+| `NoShrinkBoth` | Do not shrink on either side. |
+
+### Additional Position Instructions
+
+| Instruction | Description |
+|---|---|
+| `initialize_position2` | Creates a position, succeeding silently if it already exists (idempotent). |
+| `close_position_if_empty` | Closes a position only if it has no liquidity; otherwise does nothing. |
+| `migrate_position` | Migrates a v1 position to v2 format. |
+
+## Bin Array Initialization
+
+<Warning>
+**Breaking change:** The `initialize_bin_array` instruction now sets all bin prices during initialization and consumes approximately **250,000 compute units**. Integrations should allocate additional CU for this instruction. The instruction is idempotent — re-initializing an existing bin array does not return an error.
+</Warning>
+
+## Token 2022 Support
+
+DLMM supports Token 2022 tokens with the following permissionless extensions:
+
+- `TransferFeeConfig` / `TransferFeeAmount`
+- `TokenMetadata` / `MetadataPointer`
+- `ConfidentialTransferMint` / `ConfidentialTransferFeeConfig`
+
+Extensions like `PermanentDelegate`, `TransferHook`, and `MintCloseAuthority` require a **Token Badge** to be initialized by the program admin before they can be used in DLMM pools.
+
+<Note>Transfer hook mints are supported permissionlessly if both the transfer hook program and transfer hook authority have been revoked.</Note>
 
 ## Official SDKs
 

--- a/developer-guide/guides/dlmm/overview.mdx
+++ b/developer-guide/guides/dlmm/overview.mdx
@@ -50,6 +50,47 @@ We also outline a list of unofficial community SDKs made by our wonderful commun
   </table>
 </div>
 
+## Operator Permission System
+
+DLMM v0.11.0 introduces an operator account system. An operator account can be created by an authorized party and delegated a subset of discrete permissions, allowing third parties (such as market makers or bots) to manage specific pool and program parameters without holding full authority.
+
+Supported permissions include:
+
+| Permission | Description |
+|---|---|
+| `InitializePermissionedPool` | Create a permissioned pool |
+| `InitializePresetParameter` | Create a preset bin step / fee parameter |
+| `ClaimProtocolFee` | Collect accrued protocol fees |
+| `ZapProtocolFee` | Zap collected protocol fees to a target token |
+| `InitializeReward` | Set up a farming reward on a pool |
+| `UpdateRewardFunder` | Change the reward funder address |
+| `UpdateRewardDuration` | Adjust reward distribution duration |
+| `UpdateFeeParameters` | Modify base fee and variable fee parameters |
+| `SetPairStatus` | Enable or disable swaps on a pool |
+| `InitializeTokenBadge` | Register a Token 2022 token badge |
+| `CloseTokenBadge` | Remove a token badge |
+| `ClosePresetParameter` | Remove a preset parameter account |
+| `ResetTombstoneFields` | Reset tombstone fields on a closed account |
+
+Operator accounts are managed via the `create_operator_account` and `close_operator_account` instructions.
+
+## Dynamic Positions
+
+DLMM v0.11.0 introduces `PositionV2`, which supports up to **1,400 bins** per position — a significant increase from the previous 70-bin limit. This is achieved through extended byte data attached to the position account, which is allocated on demand as the position grows.
+
+Positions can also be resized dynamically on both the lower and upper sides, allowing liquidity ranges to be expanded without closing and reopening positions.
+
+## Pool Types
+
+DLMM supports four pool types:
+
+| Pool Type | Description |
+|---|---|
+| `Permissionless` | Standard open pool, no special requirements |
+| `PermissionlessV2` | Updated permissionless pool with extended capabilities |
+| `Permission` | Pool restricted to permissioned participants |
+| `CustomizablePermissionless` | Open pool with creator-controlled on/off switch and customizable fee parameters |
+
 ## Official SDKs
 
 <CardGroup cols={2}>

--- a/developer-guide/trading-terminals/integrate-with-damm-v2.mdx
+++ b/developer-guide/trading-terminals/integrate-with-damm-v2.mdx
@@ -204,7 +204,7 @@ The `fee_version` field on a pool state indicates its version. Pool version dete
 | 1 (V1) | 99% |
 
 <Info>
-All newly created pools are V1. V0 pools can be upgraded to V1 using the `fix_pool_layout_version` instruction.
+All newly created pools are V1.
 </Info>
 
 ## Plotting Charts

--- a/developer-guide/trading-terminals/integrate-with-damm-v2.mdx
+++ b/developer-guide/trading-terminals/integrate-with-damm-v2.mdx
@@ -24,10 +24,6 @@ Base Fees includes either a Flat Fee, Fee Scheduler, Rate Limiter, or Fee Market
     - 4 = Exponential Fee Market Cap Scheduler
 </Note>
 
-<Info>
-    **Pool Version Note:** Pool Version V1 supports up to 99% max fee (increased from V0's 50% max fee).
-</Info>
-
 #### Decoding BaseFee
 
 The `baseFee.data` field is a `number[]` (byte array) that requires decoding when indexed. The decoder type depends on the **data source** and **`baseFeeMode`**.
@@ -198,6 +194,19 @@ Here are some examples of how the Fee Market Cap Scheduler works:
 
 You can refer to the Dynamic Fee calculation [here](/overview/products/damm-v2/pool-fees-calculation#dynamic-fee-variable-fee)
 
+## Pool Version (fee_version)
+
+The `fee_version` field on a pool state indicates its version. Pool version determines the maximum allowed fee.
+
+| `fee_version` | Max Fee |
+|---|---|
+| 0 (V0) | 50% |
+| 1 (V1) | 99% |
+
+<Info>
+All newly created pools are V1. V0 pools can be upgraded to V1 using the `fix_pool_layout_version` instruction.
+</Info>
+
 ## Plotting Charts
 
 <Danger>Using Transfer logs from Swap transactions is not the correct way of getting the token price as we have Anti-Sniper Suite features that can cause huge fee deductions from `TokenAmountIn` OR `TokenAmountOut`. Plotting the token chart price from these will lead to a very ugly chart.</Danger>
@@ -211,7 +220,7 @@ Because of the Anti-Sniper Suite features, you will have to apply the following 
 [1.1] Firstly, you will need to identify where the fees are coming from (either from input or output): 
 
 ```
-feeOnInput: (collectFeeMode == 1 && tradeDirection == 1)? true: false
+feeOnInput: (collectFeeMode == 1 && tradeDirection == 1) || (collectFeeMode == 2 && tradeDirection == 1) ? true : false
 ```
 
 [1.2] Next, calculate the amount and plot price depending on where the fees are coming from (either from input or output):
@@ -219,7 +228,46 @@ feeOnInput: (collectFeeMode == 1 && tradeDirection == 1)? true: false
 ```
 if (feeOnInput): price = excludedFeeInputAmount / outputAmount
 
-if (!feeOnInput): price = excludedFeeInputAmount / outputAmount + tradingFee + protocolFee + referralFee + partnerFee
+if (!feeOnInput): price = excludedFeeInputAmount / (outputAmount + tradingFee + protocolFee + referralFee + compoundingFee)
+```
+
+<Warning>
+**Breaking change in v0.2.0:** `EvtSwap2` no longer contains a `partner_fee` field. It has been replaced by `compounding_fee`. Update any integrations that previously read `partner_fee` from swap CPI logs to use `compounding_fee` instead.
+
+The total trading fee is now: `tradingFee = claimingFee + compoundingFee`
+</Warning>
+
+### Collect Fee Mode 2 (Compounding)
+
+When `collectFeeMode == 2`, the pool operates in **Compounding** mode. This affects how you interpret swap events and price calculations:
+
+- Fees are always collected in Token B (quote token), regardless of trade direction.
+- For B→A trades (`tradeDirection == 1`), fees are deducted from the input amount (`feeOnInput = true`).
+- A percentage of the fee (configured by `compounding_fee_bps`) is automatically reinvested back into the pool reserves rather than being claimable by LPs. This portion appears as `compounding_fee` in `EvtSwap2`.
+- The pool uses a constant-product formula (no concentrated liquidity range) in this mode.
+
+**Fee collection summary by mode and direction:**
+
+| `collectFeeMode` | A→B trade | B→A trade |
+|---|---|---|
+| 0 (BothToken) | Fee on B (output) | Fee on A (output) |
+| 1 (OnlyB) | Fee on B (output) | Fee on B (input) |
+| 2 (Compounding) | Fee on B (output) | Fee on B (input) + auto-compound |
+
+**`SwapResult2` fields (v0.2.0+):**
+
+```typescript
+interface SwapResult2 {
+  included_fee_input_amount: BN;   // Input amount including fee (when feeOnInput)
+  excluded_fee_input_amount: BN;   // Input amount excluding fee
+  amount_left: BN;                 // Remaining amount after swap
+  output_amount: BN;               // Output amount to recipient
+  next_sqrt_price: BN;             // Pool sqrt price after swap
+  claiming_fee: BN;                // Fee claimable by LPs
+  compounding_fee: BN;             // Fee auto-reinvested into reserves (replaces partner_fee)
+  protocol_fee: BN;                // Fee taken by protocol
+  referral_fee: BN;                // Fee taken by referral account
+}
 ```
 
 ## Trading Volume

--- a/developer-guide/trading-terminals/integrate-with-dbc.mdx
+++ b/developer-guide/trading-terminals/integrate-with-dbc.mdx
@@ -274,6 +274,18 @@ MigrationProgress::LockedVesting    // 2
 MigrationProgress::CreatedPool      // 3
 ```
 
+### Post-Migration Fee Collection Mode (DAMM v2)
+
+When a DBC pool graduates to DAMM v2, the fee collection behavior depends on the `collectFeeMode` set in the pool's `migratedPoolFee` config. Trading terminals should be aware of these modes when displaying fee or liquidity information for graduated pools:
+
+| `collectFeeMode` | Behavior |
+|---|---|
+| `0` (QuoteToken) | Fees accumulate in the quote token. Maps to DAMM v2 `OnlyB`. |
+| `1` (OutputToken) | Fees accumulate in the output token of each trade. Maps to DAMM v2 `BothToken`. |
+| `2` (Compounding) | Fees are automatically reinvested into the LP position. No separate claimable fee balance accumulates. |
+
+<Note>For graduated DAMM v2 pools with `collectFeeMode: 2` (Compounding), trading fee revenue is reflected in growing LP position value rather than a separate fee balance. Displaying "claimable fees" for these pools is not applicable.</Note>
+
 ### Meteora's DBC Migration Keepers
 
 - We run a total of 2 DBC Migration Keepers to migrate the DBC pools. These migration keepers each have their individual threshold requirements of >= 750 USD worth of `quoteReserve` to migrate the pool provided `quoteReserve >= migrationQuoteThreshold`.

--- a/overview/products/damm-v2/collect-fee-modes.mdx
+++ b/overview/products/damm-v2/collect-fee-modes.mdx
@@ -17,7 +17,7 @@ Every DAMM v2 pool has a `collectFeeMode` that determines how trading fees flow 
 
 ## BothToken (mode 0)
 
-Fees accumulate in whichever token the LP provided. When a trader swaps A→B, the fee is taken in token A. When they swap B→A, the fee is taken in token B.
+Fees accumulate in the output token of each swap. When a trader swaps A→B, the fee is taken from the output (token B). When they swap B→A, the fee is taken from the output (token A).
 
 **LP fee claim:** Separate `claimPositionFee` instruction. Both `fee_a_pending` and `fee_b_pending` on the position are claimable.
 
@@ -27,7 +27,7 @@ Fees accumulate in whichever token the LP provided. When a trader swaps A→B, t
 
 ## OnlyB (mode 1)
 
-All fees are collected in token B (the quote token), regardless of swap direction. Fees for A→B swaps are still taken from the input (token A) but immediately converted to the quote token equivalent.
+All fees are collected in token B (the quote token), regardless of swap direction. For A→B swaps, the fee is taken from the output token (token B) directly. For B→A swaps, the fee is taken from the output token (token A) and then converted to the quote token (token B) internally.
 
 **LP fee claim:** Only `fee_b_pending` accumulates. `fee_a_pending` is always 0.
 
@@ -42,9 +42,11 @@ The most distinctive mode. A configurable percentage of each trade's LP fee (`co
 ### How it works
 
 ```
-Trading Fee (LP portion)
-  ├── compoundingFeeBps / 10000 → added to pool token B reserves (grows pool liquidity)
-  └── remainder → fee_b_pending (claimable by LP)
+Total Trading Fee
+  ├── Protocol Fee  (protocol_fee_percent % of total trading fee)
+  └── LP Fee (remainder)
+        ├── compoundingFeeBps / 10000 → added to pool token B reserves (grows pool liquidity)
+        └── remainder → fee_b_pending (claimable by LP)
 ```
 
 `compoundingFeeBps` is a u16 (0–10000). E.g., `5000` = 50% of LP fees compound, 50% claimable.

--- a/overview/products/damm-v2/damm-v2-fee-calculation.mdx
+++ b/overview/products/damm-v2/damm-v2-fee-calculation.mdx
@@ -7,7 +7,11 @@ DAMM v2 LPs earn a swap fee from traders when they perform a swap. The fees can 
 
 - **BothToken (0)** — fees claimable in both base and quote tokens
 - **OnlyB (1)** — fees claimable in quote token only
-- **Compounding (2)** — a configurable portion of fees is automatically reinvested into pool liquidity; the remainder is claimable
+- **Compounding (2)** — a configurable percentage of fees is automatically reinvested back into the pool reserves; the remainder is claimable
+
+<Note>In BothToken and OnlyB modes, fees are not compounded into pool liquidity and can be claimed separately. In Compounding mode, a portion of fees is automatically reinvested — see [Compounding Fee Mode](#compounding-fee-mode) below.</Note>
+
+<Warning>**Breaking change in v0.2.0:** The `partner_fee` field has been removed from DAMM v2. It has been replaced by `compounding_fee` in the `EvtSwap2` event. If you were tracking `partner_fee` in your integrations, update your code to use `compounding_fee` instead.</Warning>
 
 # Total Trading Fee
 
@@ -112,7 +116,39 @@ The decay mechanism is based on the time elapsed since the last significant trad
 
 If you set the `useDynamicFee` to `true` in the config key when you deploy via [DAMM v2 Launch Pool](/developer-guide/quick-launch/damm-v2-launch-pool), the max dynamic fee on DAMM v2 will be less than or equals to 20% of the Base Fee. You can also choose to configure the dynamic fee manually based on the math formula above.
 
-**Example:** 
+**Example:**
 - Base Fee = 1%
 - Dynamic Fee = 0.2%
 - Total Trading/LP Fee = 1.2%
+
+# Compounding Fee Mode
+
+Compounding Fee Mode is a third fee collection option (`collect_fee_mode = 2`) where a configurable percentage of trading fees is automatically reinvested into the pool reserves, instead of being held for LP claiming. The rest of the fee is still claimable by LPs as normal.
+
+This mode is configured using the `compounding_fee_bps` parameter, which defines how many basis points of the LP fee are compounded. For example, a value of 5000 means 50% of the trading fee auto-compounds, and the remaining 50% is claimable.
+
+<Note>Pools using Compounding Fee Mode operate as a standard constant-product AMM with no concentrated price range. See [DAMM v2 Formulas](/overview/products/damm-v2/damm-v2-formulas) for details.</Note>
+
+## Fee Split
+
+The protocol fee is calculated from the total trading fee ($f_s$) before the split. The remainder is then divided between the claiming fee and the compounding fee:
+
+```math
+\text{claiming\_fee} = f_s \times \left(1 - \frac{\text{compounding\_fee\_bps}}{10000}\right)
+```
+
+```math
+\text{compounding\_fee} = f_s \times \frac{\text{compounding\_fee\_bps}}{10000}
+```
+
+So:
+
+```math
+f_s = \text{claiming\_fee} + \text{compounding\_fee}
+```
+
+**Example:**
+- Total trading fee ($f_s$) = 1%
+- `compounding_fee_bps` = 3000 (30%)
+- Compounding fee = 0.3% (auto-reinvested into pool reserves)
+- Claiming fee = 0.7% (claimable by LPs)

--- a/overview/products/damm-v2/damm-v2-fee-calculation.mdx
+++ b/overview/products/damm-v2/damm-v2-fee-calculation.mdx
@@ -131,24 +131,34 @@ This mode is configured using the `compounding_fee_bps` parameter, which defines
 
 ## Fee Split
 
-The protocol fee is calculated from the total trading fee ($f_s$) before the split. The remainder is then divided between the claiming fee and the compounding fee:
+The protocol fee is first subtracted from the total trading fee. The compounding/claiming split then applies to the remaining LP fee:
 
 ```math
-\text{claiming\_fee} = f_s \times \left(1 - \frac{\text{compounding\_fee\_bps}}{10000}\right)
+\text{protocol\_fee} = f_s \times \frac{\text{protocol\_fee\_percent}}{100}
 ```
 
 ```math
-\text{compounding\_fee} = f_s \times \frac{\text{compounding\_fee\_bps}}{10000}
+\text{lp\_fee} = f_s - \text{protocol\_fee}
+```
+
+```math
+\text{compounding\_fee} = \text{lp\_fee} \times \frac{\text{compounding\_fee\_bps}}{10000}
+```
+
+```math
+\text{claiming\_fee} = \text{lp\_fee} - \text{compounding\_fee}
 ```
 
 So:
 
 ```math
-f_s = \text{claiming\_fee} + \text{compounding\_fee}
+\text{lp\_fee} = \text{claiming\_fee} + \text{compounding\_fee}
 ```
 
 **Example:**
 - Total trading fee ($f_s$) = 1%
+- Protocol fee = 10% of total → 0.1%
+- LP fee = 0.9%
 - `compounding_fee_bps` = 3000 (30%)
-- Compounding fee = 0.3% (auto-reinvested into pool reserves)
-- Claiming fee = 0.7% (claimable by LPs)
+- Compounding fee = 0.27% (auto-reinvested into pool reserves)
+- Claiming fee = 0.63% (claimable by LPs)

--- a/overview/products/damm-v2/damm-v2-fee-calculation.mdx
+++ b/overview/products/damm-v2/damm-v2-fee-calculation.mdx
@@ -11,8 +11,6 @@ DAMM v2 LPs earn a swap fee from traders when they perform a swap. The fees can 
 
 <Note>In BothToken and OnlyB modes, fees are not compounded into pool liquidity and can be claimed separately. In Compounding mode, a portion of fees is automatically reinvested — see [Compounding Fee Mode](#compounding-fee-mode) below.</Note>
 
-<Warning>**Breaking change in v0.2.0:** The `partner_fee` field has been removed from DAMM v2. It has been replaced by `compounding_fee` in the `EvtSwap2` event. If you were tracking `partner_fee` in your integrations, update your code to use `compounding_fee` instead.</Warning>
-
 # Total Trading Fee
 
 The total swap fee ($f_s$) will have two components:

--- a/overview/products/damm-v2/damm-v2-formulas.mdx
+++ b/overview/products/damm-v2/damm-v2-formulas.mdx
@@ -37,13 +37,13 @@ The farming rewards are calculated as:
 
 <div style={{ fontSize: "0.85em" }}>
 ```math
-\text{Reward per token} = \frac{\text{Elapsed Time} \times \text{Reward Rate} \times 2^{64}}{\text{Total Liquidity}}
+\text{Reward per token} = \frac{\text{Elapsed Time} \times \text{Reward Rate} \times 2^{128}}{\text{Total Liquidity}}
 ```
 </div>
 
 <div style={{ fontSize: "0.85em" }}>
 ```math
-\text{User reward} = \text{Position Liquidity} \times (\text{Current Reward per Token} - \text{User Last Reward per Token}) \gg 64
+\text{User reward} = \text{Position Liquidity} \times (\text{Current Reward per Token} - \text{User Last Reward per Token}) \gg 192
 ```
 </div>
 
@@ -65,14 +65,22 @@ where $k$ is a constant. Unlike the standard DAMM v2 concentrated liquidity form
 
 ## Fee Split Formulas
 
-The total trading fee ($f_s$) is split between the claimable LP fee and the compounding fee:
+The protocol fee is first subtracted from the total trading fee. The compounding/claiming split then applies to the LP fee (after protocol fee is removed):
 
 ```math
-\text{claiming\_fee} = f_s \times \left(1 - \frac{\text{compounding\_fee\_bps}}{10000}\right)
+\text{protocol\_fee} = f_s \times \frac{\text{protocol\_fee\_percent}}{100}
 ```
 
 ```math
-\text{compounding\_fee} = f_s \times \frac{\text{compounding\_fee\_bps}}{10000}
+\text{lp\_fee} = f_s - \text{protocol\_fee}
+```
+
+```math
+\text{compounding\_fee} = \text{lp\_fee} \times \frac{\text{compounding\_fee\_bps}}{10000}
+```
+
+```math
+\text{claiming\_fee} = \text{lp\_fee} - \text{compounding\_fee}
 ```
 
 The compounding fee is added directly to the pool reserves, increasing $k$ over time and benefiting all LPs proportionally.

--- a/overview/products/damm-v2/damm-v2-formulas.mdx
+++ b/overview/products/damm-v2/damm-v2-formulas.mdx
@@ -47,6 +47,36 @@ The farming rewards are calculated as:
 ```
 </div>
 
+# Compounding Fee Mode
+
+When a pool uses Compounding Fee Mode (`collect_fee_mode = 2`), it operates as a standard constant-product AMM with no concentrated price range. The pool reserves grow over time as a portion of trading fees are automatically reinvested.
+
+## Constant-Product Formula
+
+The pool maintains the invariant:
+
+```math
+\text{token\_a\_amount} \times \text{token\_b\_amount} = k
+```
+
+where $k$ is a constant. Unlike the standard DAMM v2 concentrated liquidity formula, there is no `sqrt_min_price` or `sqrt_max_price` bound — liquidity spans the full price range.
+
+<Note>Pools with `layout_version == 1` track `token_a_amount` and `token_b_amount` directly in the pool state, enabling accurate reserve accounting for the compounding mechanism.</Note>
+
+## Fee Split Formulas
+
+The total trading fee ($f_s$) is split between the claimable LP fee and the compounding fee:
+
+```math
+\text{claiming\_fee} = f_s \times \left(1 - \frac{\text{compounding\_fee\_bps}}{10000}\right)
+```
+
+```math
+\text{compounding\_fee} = f_s \times \frac{\text{compounding\_fee\_bps}}{10000}
+```
+
+The compounding fee is added directly to the pool reserves, increasing $k$ over time and benefiting all LPs proportionally.
+
 # Price Impact
 
 The price impact for a swap can be calculated as:

--- a/overview/products/damm-v2/farming-rewards.mdx
+++ b/overview/products/damm-v2/farming-rewards.mdx
@@ -53,7 +53,7 @@ const tx = await cpAmm.initializeReward({
 
 **Constraints:**
 - `reward_index` must be 0 or 1 (`InvalidRewardIndex` if out of range)
-- `reward_duration` must be > 0 (`InvalidRewardDuration`)
+- `reward_duration` must be between 86400 seconds (1 day) and 31536000 seconds (1 year) (`InvalidRewardDuration`)
 - Cannot re-initialize an already active slot (`RewardInitialized`)
 
 **Event emitted:** `EvtInitializeReward`

--- a/overview/products/damm-v2/fee-configuration.mdx
+++ b/overview/products/damm-v2/fee-configuration.mdx
@@ -16,7 +16,7 @@ Gross Input Amount
               └── [Compounding only] compoundingFeeBps / 10000 → pool reserves
 ```
 
-All fee rates are stored as numerators over a fixed denominator (`FEE_DENOMINATOR = 1,000,000`), giving 6 decimal places of precision (e.g., fee rate of `2500` = 0.25%).
+All fee rates are stored as numerators over a fixed denominator (`FEE_DENOMINATOR = 1,000,000,000`), giving 9 decimal places of precision (e.g., fee rate of `2,500,000` = 0.25%).
 
 ---
 
@@ -37,7 +37,7 @@ passed_period = (current_point - activation_point) / period_frequency
 
 | Field | Description |
 |-------|-------------|
-| `cliff_fee_numerator` | Starting fee rate (numerator over 1,000,000) |
+| `cliff_fee_numerator` | Starting fee rate (numerator over 1,000,000,000) |
 | `number_of_period` | How many periods to decay over |
 | `period_frequency` | Slots or seconds per period |
 | `reduction_factor` | How much to reduce per period |
@@ -133,8 +133,8 @@ Protocol fees are accumulated in the pool and claimed by the admin via `claimPro
 
 | Constraint | Value |
 |------------|-------|
-| Max total fee | 99% (`MAX_FEE_NUMERATOR = 990_000`) |
-| Fee denominator | `1_000_000` |
+| Max total fee | 99% (`MAX_FEE_NUMERATOR = 990_000_000`) |
+| Fee denominator | `1_000_000_000` |
 | Min fee (floor) | Set by `get_min_fee_numerator()` per mode |
 | `compoundingFeeBps` range | 0–10000 (only for mode 2) |
 

--- a/overview/products/damm-v2/pool-types.mdx
+++ b/overview/products/damm-v2/pool-types.mdx
@@ -118,7 +118,7 @@ On-chain, a pool account stores:
 | `collectFeeMode` | `u8` | Fee collection mode |
 | `activationPoint` | `u64` | Trading activation point |
 | `poolStatus` | `u8` | Pool enabled/disabled status |
-| `poolType` | `u8` | 0 = SPL Token, 1 = Token 2022 |
+| `poolType` | `u8` | 0 = Permissionless, 1 = Customizable |
 | `feeAPerTokenStored` | `[u8; 32]` | Cumulative fee A per unit liquidity (U256) |
 | `feeBPerTokenStored` | `[u8; 32]` | Cumulative fee B per unit liquidity (U256) |
 | `rewardInfos` | `[RewardInfo; 2]` | Farming reward state (2 slots) |

--- a/overview/products/damm-v2/position-management.mdx
+++ b/overview/products/damm-v2/position-management.mdx
@@ -134,7 +134,7 @@ A position can be split into two positions using `splitPosition`. This is useful
 - Transferring a portion of a position to a different wallet
 - LP token distribution events
 
-The split is specified as a numerator over `SPLIT_POSITION_DENOMINATOR` (10,000). E.g., `split_numerator = 5000` splits the position 50/50.
+The split is specified as a numerator over `SPLIT_POSITION_DENOMINATOR` (1,000,000,000). E.g., `split_numerator = 500_000_000` splits the position 50/50.
 
 The split proportionally divides:
 - `unlocked_liquidity`

--- a/overview/products/damm-v2/what-is-damm-v2.mdx
+++ b/overview/products/damm-v2/what-is-damm-v2.mdx
@@ -41,7 +41,70 @@ DAMM v2 comes with the following features.
   </Card>
 </CardGroup>
 
----
+# Pool Creation Options
+
+DAMM v2 supports three ways to create a pool, each offering different levels of control:
+
+| Method | Description |
+|---|---|
+| `initialize_pool` | Creates a pool using a pre-defined **static config** created by Meteora. Fee parameters are fixed. |
+| `initialize_pool_with_dynamic_config` | Creates a pool using a **dynamic config**. The pool creator defines all fee parameters during creation. |
+| `initialize_customizable_pool` | Creates a **fully customizable** pool where the pool creator sets all parameters including fee mode, dynamic fees, and compounding settings. |
+
+<Note>All three creation methods support `collect_fee_mode = 2` (Compounding) and `compounding_fee_bps` configuration.</Note>
+
+# Position Features
+
+Each liquidity position in DAMM v2 is represented by an NFT, making positions transferable between wallets.
+
+## Liquidity Locking & Vesting
+
+Positions support three liquidity states:
+
+| State | Description |
+|---|---|
+| **Unlocked** | Can be withdrawn at any time by the position owner. |
+| **Vesting** | Time-locked liquidity that gradually becomes unlocked based on a cliff + periodic release schedule. |
+| **Permanently Locked** | Cannot be withdrawn ever, but still earns trading fees and farming rewards. |
+
+Use `lock_position` or `lock_inner_position` to vest liquidity directly within a position (no separate vesting account required). Use `permanent_lock_position` to permanently lock liquidity. Call `refresh_vesting` to release vested liquidity that has reached its unlock time.
+
+<Note>`lock_inner_position` stores vesting state inside the position itself, enabling better composability with other programs.</Note>
+
+## Position Splitting
+
+Position owners can split a position into two using `split_position` or `split_position2`. The split proportionally divides:
+
+- Unlocked, vested, and permanently locked liquidity
+- Pending trading fees (both tokens)
+- Pending farming rewards
+- Inner vesting state
+
+This is useful for partially transferring or selling a portion of a position.
+
+# Swap Modes
+
+DAMM v2 supports two swap instructions:
+
+| Instruction | Modes |
+|---|---|
+| `swap` | ExactIn only (deprecated) |
+| `swap2` | ExactIn (0), PartialFill (1), ExactOut (2) |
+
+<Warning>The original `swap` instruction and the `EvtSwap`, `EvtRemoveLiquidity`, and `EvtAddLiquidity` events are deprecated. Use `swap2` and `EvtSwap2` / `EvtLiquidityChange` instead.</Warning>
+
+<Note>For pools with Rate Limiter enabled (`baseFeeMode == 2`), the `SYSVAR_INSTRUCTIONS_PUBKEY` must be included in the remaining accounts of the swap instruction.</Note>
+
+# Farming Rewards
+
+DAMM v2 has a built-in farming mechanism (no separate farm program required). Each pool supports up to **2 reward tokens** simultaneously.
+
+- Pool creators can permissionlessly initialize the first reward (index 0) for their own pool
+- Rewards are distributed proportionally based on position liquidity (including unlocked, vesting, and permanently locked)
+- LPs claim rewards via `claim_reward`
+- The `skip_reward` parameter allows claiming even if a reward vault is frozen
+
+# Case Studies
 
 ## Program Address
 

--- a/overview/products/damm-v2/what-is-damm-v2.mdx
+++ b/overview/products/damm-v2/what-is-damm-v2.mdx
@@ -7,6 +7,10 @@ description: "DAMM v2 is Meteora's concentrated-liquidity constant-product AMM. 
 
 DAMM v2 (Dynamic AMM v2) is Meteora's next-generation liquidity protocol on Solana. Built on the **cp-amm** program, it gives token creators and LPs fine-grained control over how pools are configured, how fees are collected, and how liquidity is locked and released.
 
+# Key Features
+
+DAMM v2 comes with the following features.
+
 <CardGroup cols={2}>
   <Card title="Concentrated Liquidity" icon="chart-line" iconType="solid">
     LPs concentrate capital in a chosen price range to earn more fees per dollar deployed. Supports full-range (x·y=k) as a special case.
@@ -22,6 +26,9 @@ DAMM v2 (Dynamic AMM v2) is Meteora's next-generation liquidity protocol on Sola
   </Card>
   <Card title="Liquidity Vesting" icon="lock" iconType="solid">
     Lock liquidity with cliff + linear vesting schedules, or lock permanently. Both inner vesting (single account) and external vesting accounts supported.
+  </Card>
+  <Card title="Compounding Fee Mode" icon="arrows-rotate" iconType="solid">
+    A percentage of trading fees can be set to auto-compound directly into pool reserves via `compounding_fee_bps`. The pool operates as a standard constant-product AMM in this mode, with no concentrated price range.
   </Card>
   <Card title="Anti-Sniper Controls" icon="shield" iconType="solid">
     Set an activation point (by slot or timestamp) to delay trading. Pair with an Alpha Vault or presale vault for whitelisted early access.

--- a/overview/products/dbc/bonding-curve-formulas.mdx
+++ b/overview/products/dbc/bonding-curve-formulas.mdx
@@ -155,7 +155,7 @@ We introduced a new migration fee feature that allows users to collect a percent
 ```
 migrationFee: {
     // Optional migration fee (set as 0 for feePercentage and 0 for creatorFeePercentage for no migration fee)
-    feePercentage: number // The percentage of fee taken from migration quote threshold (0-50)
+    feePercentage: number // The percentage of fee taken from migration quote threshold (0-99)
     creatorFeePercentage: number // The fee share percentage for the creator from the migration fee (0-100)
 }
 ```

--- a/overview/products/dbc/curve-configuration.mdx
+++ b/overview/products/dbc/curve-configuration.mdx
@@ -16,7 +16,7 @@ pub struct LiquidityDistributionConfig {
 }
 ```
 
-Up to `MAX_CURVE_POINT_CONFIG` = **16** points.
+Up to **16** price points (`MAX_CURVE_POINT`).
 
 ---
 

--- a/overview/products/dbc/dbc-config-key.mdx
+++ b/overview/products/dbc/dbc-config-key.mdx
@@ -20,7 +20,7 @@ A DBC Config Key is a unique configuration key that will dictate your curve stru
   </Card>
   
   <Card title="Fee Collection Mode" icon="binary">
-    <p>Determines fee collection: Only Quote tokens or Both Quote and Base tokens</p>
+    <p>Determines fee collection: Only Quote tokens or Output token of each swap</p>
   </Card>
   
   <Card title="Activation Type" icon="typewriter">
@@ -45,7 +45,7 @@ A DBC Config Key is a unique configuration key that will dictate your curve stru
       <li><strong>Fee Config</strong> - Base fees for migrated pools (0.25%, 0.3%, 1%, 2%, 4% and 6%)</li>
       <li><strong>Migration Quote Threshold</strong> - Minimum quote amount for migration</li>
       <li><strong>Migration Fee</strong> - Collect a percentage of fees from the pool's quote reserve</li>
-      <li><strong>Migrated Pool Base Fee Mode</strong> - Fee mode for the graduated DAMM v2 pool: FeeTimeSchedulerLinear (0), FeeTimeSchedulerExponential (1), FeeMarketCapSchedulerLinear (3), or FeeMarketCapSchedulerExponential (4)</li>
+      <li><strong>Migrated Pool Base Fee Mode</strong> - Fee mode for the graduated DAMM v2 pool: FeeTimeSchedulerLinear (0), FeeTimeSchedulerExponential (1), RateLimiter (2), FeeMarketCapSchedulerLinear (3), or FeeMarketCapSchedulerExponential (4)</li>
       <li><strong>Market Cap Fee Scheduler Params</strong> - Configure fee reduction based on price movement for DAMM v2 pools (number of periods, sqrt price step, expiration duration)</li>
       <li><strong>First Swap with Min Fee</strong> - Allow the first swap to use minimum fee for creator bundled buys</li>
       <li><strong>Compounding Fee Mode</strong> - For DAMM v2 graduated pools, set <code>collectFeeMode: 2</code> (Compounding) to reinvest trading fees back into the LP position. Requires <code>compoundingFeeBps</code> to be set to a non-zero value.</li>

--- a/overview/products/dbc/dbc-config-key.mdx
+++ b/overview/products/dbc/dbc-config-key.mdx
@@ -48,7 +48,19 @@ A DBC Config Key is a unique configuration key that will dictate your curve stru
       <li><strong>Migrated Pool Base Fee Mode</strong> - Fee mode for the graduated DAMM v2 pool: FeeTimeSchedulerLinear (0), FeeTimeSchedulerExponential (1), FeeMarketCapSchedulerLinear (3), or FeeMarketCapSchedulerExponential (4)</li>
       <li><strong>Market Cap Fee Scheduler Params</strong> - Configure fee reduction based on price movement for DAMM v2 pools (number of periods, sqrt price step, expiration duration)</li>
       <li><strong>First Swap with Min Fee</strong> - Allow the first swap to use minimum fee for creator bundled buys</li>
+      <li><strong>Compounding Fee Mode</strong> - For DAMM v2 graduated pools, set <code>collectFeeMode: 2</code> (Compounding) to reinvest trading fees back into the LP position. Requires <code>compoundingFeeBps</code> to be set to a non-zero value.</li>
+      <li><strong>compoundingFeeBps</strong> - The fee rate (in basis points) applied when compounding fees back into the LP position. Must be non-zero when Compounding mode is active, and must be 0 for all other modes.</li>
     </ul>
+  </Card>
+
+  <Card title="Migrated Pool Fee Configuration (DAMM v2 only)" icon="money-bill-transfer">
+    <p>When your pool migrates to DAMM v2 and you use the Customizable fee option, you can set the <code>migratedPoolFee</code> struct with these options:</p>
+    <ul>
+      <li><strong>QuoteToken (0)</strong> - Fees collected in the quote token only (maps to DAMM v2 <em>OnlyB</em> mode)</li>
+      <li><strong>OutputToken (1)</strong> - Fees collected in both tokens (maps to DAMM v2 <em>BothToken</em> mode)</li>
+      <li><strong>Compounding (2)</strong> - Fees are automatically reinvested back into the liquidity position, growing LP value over time instead of accumulating as separate claimable fees</li>
+    </ul>
+    <p><em>Note: SOL and USDC fees cannot be zapped and must be claimed directly when using the Compounding mode.</em></p>
   </Card>
   
   <Card title="Liquidity Percentages" icon="percent">

--- a/overview/products/dbc/dbc-config-key.mdx
+++ b/overview/products/dbc/dbc-config-key.mdx
@@ -60,7 +60,6 @@ A DBC Config Key is a unique configuration key that will dictate your curve stru
       <li><strong>OutputToken (1)</strong> - Fees collected in both tokens (maps to DAMM v2 <em>BothToken</em> mode)</li>
       <li><strong>Compounding (2)</strong> - Fees are automatically reinvested back into the liquidity position, growing LP value over time instead of accumulating as separate claimable fees</li>
     </ul>
-    <p><em>Note: SOL and USDC fees cannot be zapped and must be claimed directly when using the Compounding mode.</em></p>
   </Card>
   
   <Card title="Liquidity Percentages" icon="percent">

--- a/overview/products/dbc/dbc-fee-calculation.mdx
+++ b/overview/products/dbc/dbc-fee-calculation.mdx
@@ -118,3 +118,41 @@ Protocol Fee is a percentage of the Total Trading Fee (i.e. base + dynamic/varia
 **Current Protocol Fees:** Protocol Fee is 20% of the Total Trading Fee.
 
 Protocol fees are collected as either Quote token, or Quote + Both tokens, depending on each pool’s configuration.
+
+# Post-Migration Fee Modes (DAMM v2 Graduated Pools)
+
+When a DBC pool graduates and migrates to DAMM v2, the fee collection behavior is controlled by the `collectFeeMode` set in the `migratedPoolFee` config. There are three modes available:
+
+## Mode 0 — QuoteToken (OnlyB)
+
+Fees from all trades are collected entirely in the quote token (e.g. SOL or USDC), regardless of trade direction. Maps to DAMM v2’s `OnlyB` collect fee mode.
+
+## Mode 1 — OutputToken (BothToken)
+
+Fees are collected in the output token of each swap. For a buy (quote → base), the fee is in the base token. For a sell (base → quote), the fee is in the quote token. Maps to DAMM v2’s `BothToken` collect fee mode.
+
+## Mode 2 — Compounding
+
+Fees are not distributed as claimable amounts. Instead, they are automatically reinvested back into the LP position, compounding the liquidity value over time.
+
+The compounding fee rate is specified in basis points via `compoundingFeeBps`:
+
+```math
+\text{compounded amount} = \text{fee collected} \times \frac{\text{compoundingFeeBps}}{10000}
+```
+
+<Note>
+When `collectFeeMode` is set to `2` (Compounding), `compoundingFeeBps` must be a non-zero value. When using any other mode, `compoundingFeeBps` must be `0`.
+</Note>
+
+<Warning>
+SOL and USDC protocol fees cannot be zapped or compounded automatically — they must be claimed directly using `claim_protocol_fee`.
+</Warning>
+
+### DBC to DAMM v2 Fee Mode Mapping
+
+| DBC `collectFeeMode` | DAMM v2 mode |
+|---|---|
+| 0 (QuoteToken) | 1 (OnlyB) |
+| 1 (OutputToken) | 0 (BothToken) |
+| 2 (Compounding) | 2 (Compounding) |

--- a/overview/products/dbc/dbc-fee-calculation.mdx
+++ b/overview/products/dbc/dbc-fee-calculation.mdx
@@ -119,6 +119,10 @@ Protocol Fee is a percentage of the Total Trading Fee (i.e. base + dynamic/varia
 
 Protocol fees are collected as either Quote token, or Quote + Both tokens, depending on each pool’s configuration.
 
+# Protocol Migration Fee
+
+A fixed **0.2% (20 bps) protocol migration fee** is applied during migration from the DBC bonding curve to the graduated DAMM pool. This fee is deducted from the quote reserve during migration and is separate from any `migrationFee` configured by the partner.
+
 # Post-Migration Fee Modes (DAMM v2 Graduated Pools)
 
 When a DBC pool graduates and migrates to DAMM v2, the fee collection behavior is controlled by the `collectFeeMode` set in the `migratedPoolFee` config. There are three modes available:
@@ -145,9 +149,6 @@ The compounding fee rate is specified in basis points via `compoundingFeeBps`:
 When `collectFeeMode` is set to `2` (Compounding), `compoundingFeeBps` must be a non-zero value. When using any other mode, `compoundingFeeBps` must be `0`.
 </Note>
 
-<Warning>
-SOL and USDC protocol fees cannot be zapped or compounded automatically — they must be claimed directly using `claim_protocol_fee`.
-</Warning>
 
 ### DBC to DAMM v2 Fee Mode Mapping
 

--- a/overview/products/dbc/dbc-fee-calculation.mdx
+++ b/overview/products/dbc/dbc-fee-calculation.mdx
@@ -39,7 +39,7 @@ The base fee of a pool can be configured by the pool creator in the following wa
 
 ### Fixed Base Fee
 
-Fixed base fee is a fixed fee that is applied to the swap amount. The fee can range from 0.01% to 99%. It is specified in the config key used for the pool creation.
+Fixed base fee is a fixed fee that is applied to the swap amount. The fee can range from 0.25% to 99%. It is specified in the config key used for the pool creation.
 
 ### Fee Scheduler
 

--- a/overview/products/dbc/migration.mdx
+++ b/overview/products/dbc/migration.mdx
@@ -93,9 +93,9 @@ A one-time migration fee is taken from the migrated quote reserves:
 migration_fee_amount = total_quote × migration_fee_bps / 10_000
 ```
 
-Split between protocol and creator:
-- `migration_fee_percentage %` → protocol
-- `creator_migration_fee_percentage %` → creator
+The `migration_fee_percentage` is the total fee percentage. This total fee is split between partner and creator:
+- Partner receives the portion not allocated to the creator
+- `creator_migration_fee_percentage %` → creator's share of the migration fee
 
 Both parties can claim their migration fee separately via `withdrawMigrationFee`.
 
@@ -111,7 +111,7 @@ After migration, there may be surplus quote tokens beyond what's needed for the 
 
 | Claimant | Instruction | Condition |
 |----------|-------------|-----------|
-| Protocol | `withdrawProtocolSurplus` | `is_protocol_withdraw_surplus = 0` |
+| Protocol | `claimProtocolFee` | Protocol surplus claimed via the unified fee claim endpoint |
 | Partner | `withdrawPartnerSurplus` | `is_partner_withdraw_surplus = 0` |
 | Creator | `withdrawCreatorSurplus` | `is_creator_withdraw_surplus = 0` |
 

--- a/overview/products/dbc/pool-configuration.mdx
+++ b/overview/products/dbc/pool-configuration.mdx
@@ -84,9 +84,9 @@ A one-time fee is deducted at migration. Options:
 | `FixedBps600` | 6.00% |
 | `Customizable` | Custom (set with a separate config for DAMM v2 migration) |
 
-Split between:
-- `migration_fee_percentage` → protocol
-- `creator_migration_fee_percentage` → creator
+The `migration_fee_percentage` is the total fee percentage taken from migration quote reserves. This total fee is then split between the partner and the creator:
+- Partner receives the portion not allocated to the creator
+- `creator_migration_fee_percentage` → creator's share of the migration fee
 
 ---
 
@@ -166,4 +166,4 @@ Setting `activation_point` to a future slot/timestamp delays all trading until t
 |-----------|-------------|
 | `pool_creation_fee` | Lamports charged to create a virtual pool from this config |
 
-This is collected from the pool creator at creation time and distributable via `claimCreatorTradingFee`.
+This is collected from the pool creator at creation time and distributable via `claimPartnerPoolCreationFee`.

--- a/overview/products/dbc/what-is-dbc.mdx
+++ b/overview/products/dbc/what-is-dbc.mdx
@@ -54,8 +54,8 @@ Dynamic Bonding Curve (DBC) lets anyone launch a token on Solana with a fully on
 DBC uses a **virtual pool** (`VirtualPool` account) during the bonding phase:
 - No real AMM pool exists yet
 - Price is determined by the current position on the bonding curve
-- Token reserves are virtual; only quote token reserves are real
-- After migration, a real DAMM pool is created and all quote liquidity moves
+- Both `base_vault` and `quote_vault` hold real tokens. Base tokens are either pre-minted (fixed supply) or minted on buy (dynamic supply). Quote tokens accumulate with each buy.
+- After migration, a real DAMM pool is created and all liquidity moves
 
 ---
 
@@ -159,8 +159,8 @@ The Dynamic Bonding Curve (DBC) virtual pool collects a trading fee on every tra
 - **Referral Fee:**  
   Swap hosts (such as Jupiter, Photon, or trading bots) can include a referral account in the swap transaction to receive a referral fee, which is taken from the protocol fee (Fixed 20% of the protocol fee).
 
-- **Fee Sharing in the Bonding Curve:**  
-  The remaining trading fee is distributed to the launch partner (Fixed 80% of the trading fee). This fee can be fee shared between the partner and the token creator.
+- **Fee Sharing in the Bonding Curve:**
+  The remaining 80% of the trading fee is the LP fee, which is split between the partner and the creator based on `creator_trading_fee_percentage`. For example, if `creator_trading_fee_percentage = 20%`, the partner gets 64% and the creator gets 16% of the total trading fee.
 
 - **Fee Distribution After Migration:**
   Once a token has graduated, the LP tokens are locked for both the partner and the token creator. The ratio of locked LP tokens is determined by the partner’s configuration. Both the partner and the token creator can claim fees from these locked LP tokens on Meteora DAMM v1 or DAMM v2. For DAMM v2 graduated pools, partners can also configure a **compounding fee mode** that reinvests trading fees back into the LP position instead of distributing them as separate claimable fees.

--- a/overview/products/dbc/what-is-dbc.mdx
+++ b/overview/products/dbc/what-is-dbc.mdx
@@ -127,7 +127,7 @@ Most launches go directly `PreBonding → LockedVesting → CreatedPool`. The `P
     Supports SOL, USDC, JUP, and other quote tokens for maximum flexibility.
   </Card>
   <Card title="SPL Token & Token2022 Support" icon="shield-check" iconType="solid">
-    Compatible with both SPL Token and Token2022 standards for broad token compatibility.
+    Compatible with both SPL Token and Token2022 standards for broad token compatibility. Note: a 0.01 SOL pool creation fee applies for Token2022 pools using Output Token fee collection mode.
   </Card>
   <Card title="Flexible Fee Collection Modes" icon="wallet" iconType="solid">
     Choose to collect fees only in the quote token or keep a percentage of all fees generated on the Dynamic Bonding Curve.
@@ -140,12 +140,6 @@ Most launches go directly `PreBonding → LockedVesting → CreatedPool`. The `P
   </Card>
   <Card title="LP Vesting (DAMM v2)" icon="clock" iconType="solid">
     Configure vesting schedules for partner and creator LP positions after migration to DAMM v2.
-  </Card>
-  <Card title="Operator Account System" icon="user-shield" iconType="solid">
-    Admins can grant whitelisted addresses permission-based operator accounts to manage protocol fee operations. Operators can be granted permission to claim protocol fees, pool creation fees, or zap protocol fees to SOL/USDC.
-  </Card>
-  <Card title="Protocol Fee Zapping" icon="bolt" iconType="solid">
-    Operators with the ZapProtocolFee permission can convert accumulated protocol fees from any token into SOL or USDC directly, without needing to claim them manually.
   </Card>
 </CardGroup>
 

--- a/overview/products/dbc/what-is-dbc.mdx
+++ b/overview/products/dbc/what-is-dbc.mdx
@@ -108,3 +108,91 @@ Most launches go directly `PreBonding → LockedVesting → CreatedPool`. The `P
     Trading fees, protocol split, creator fee, migration fee
   </Card>
 </CardGroup>
+
+# Anti-Sniper Features
+
+<CardGroup>
+  <Card title="Fee Time Scheduler" icon="clock" iconType="solid">
+    Timestamp-based fees, such as high fees at launch that decrease over time, help deter snipers and protect the pool during the most volatile periods.
+  </Card>
+  <Card title="Rate Limiter" icon="traffic-light" iconType="solid">
+    Amount-based fees that increases with a higher amount per swap, to deter snipers from sniping large amounts of tokens, while protecting smaller retail traders.
+  </Card>
+</CardGroup>
+
+# Other Features
+
+<CardGroup>
+  <Card title="Multiple Quote Token Support" icon="coins" iconType="solid">
+    Supports SOL, USDC, JUP, and other quote tokens for maximum flexibility.
+  </Card>
+  <Card title="SPL Token & Token2022 Support" icon="shield-check" iconType="solid">
+    Compatible with both SPL Token and Token2022 standards for broad token compatibility.
+  </Card>
+  <Card title="Flexible Fee Collection Modes" icon="wallet" iconType="solid">
+    Choose to collect fees only in the quote token or keep a percentage of all fees generated on the Dynamic Bonding Curve.
+  </Card>
+  <Card title="Customizable Liquidity Distribution" icon="chart-bar" iconType="solid">
+    Configure up to 16 price ranges with different liquidity curves for advanced pool customization.
+  </Card>
+  <Card title="Pool Creation Fee" icon="hand-holding-dollar" iconType="solid">
+    Partners can configure a SOL fee charged to token creators when creating pools. Partners can claim these fees via the SDK.
+  </Card>
+  <Card title="LP Vesting (DAMM v2)" icon="clock" iconType="solid">
+    Configure vesting schedules for partner and creator LP positions after migration to DAMM v2.
+  </Card>
+  <Card title="Operator Account System" icon="user-shield" iconType="solid">
+    Admins can grant whitelisted addresses permission-based operator accounts to manage protocol fee operations. Operators can be granted permission to claim protocol fees, pool creation fees, or zap protocol fees to SOL/USDC.
+  </Card>
+  <Card title="Protocol Fee Zapping" icon="bolt" iconType="solid">
+    Operators with the ZapProtocolFee permission can convert accumulated protocol fees from any token into SOL or USDC directly, without needing to claim them manually.
+  </Card>
+</CardGroup>
+
+<Warning>
+**Minimum 10% Locked Liquidity Requirement**
+
+All DBC configs require at least 10% of liquidity to remain locked at day 1 (86400 seconds) post-migration. This can be achieved through permanent locked liquidity and/or LP vesting (DAMM v2 only).
+</Warning>
+
+# Customizable Fees
+
+The Dynamic Bonding Curve (DBC) virtual pool collects a trading fee on every trade (buy or sell).
+
+- **Protocol Fee:**  
+  A portion of each trading fee is allocated to the DBC protocol (Fixed 20% of the trading fee).
+
+- **Referral Fee:**  
+  Swap hosts (such as Jupiter, Photon, or trading bots) can include a referral account in the swap transaction to receive a referral fee, which is taken from the protocol fee (Fixed 20% of the protocol fee).
+
+- **Fee Sharing in the Bonding Curve:**  
+  The remaining trading fee is distributed to the launch partner (Fixed 80% of the trading fee). This fee can be fee shared between the partner and the token creator.
+
+- **Fee Distribution After Migration:**
+  Once a token has graduated, the LP tokens are locked for both the partner and the token creator. The ratio of locked LP tokens is determined by the partner’s configuration. Both the partner and the token creator can claim fees from these locked LP tokens on Meteora DAMM v1 or DAMM v2. For DAMM v2 graduated pools, partners can also configure a **compounding fee mode** that reinvests trading fees back into the LP position instead of distributing them as separate claimable fees.
+
+# Migration
+
+### Automatic Migration
+
+If the DBC pool reaches a pre-defined quote token or price threshold, the liquidity is automatically migrated to a DAMM v1 pool or DAMM v2 Pool on Meteora.
+
+We run 2 auto migrator keepers to migrate DBC pools. These 2 keepers have strict migration quote threshold requirements.
+
+Keeper addresses that we are running:
+1. [CQdrEsYAxRqkwmpycuTwnMKggr3cr9fqY8Qma4J9TudY](https://solscan.io/account/CQdrEsYAxRqkwmpycuTwnMKggr3cr9fqY8Qma4J9TudY)
+- `pool_config.migration_quote_threshold` requirements:
+  - 10 SOL
+  - 750 USDC
+  - 1500 JUP
+2. [DeQ8dPv6ReZNQ45NfiWwS5CchWpB2BVq1QMyNV8L2uSW](https://solscan.io/account/DeQ8dPv6ReZNQ45NfiWwS5CchWpB2BVq1QMyNV8L2uSW)
+- `pool_config.migration_quote_threshold` requirements:
+  - \>= 750 USD (`quote_mint` token)
+
+<Note>The Migration Keepers only runs on Mainnet.</Note>
+
+### Manual Migration
+
+We have built a [manual migration user interface](https://migrator.meteora.ag/) for launchpads building on DBC to easily test the migration process.
+
+<Note>The Manual Migrator supports both Mainnet and Devnet.</Note>

--- a/overview/products/dlmm/dlmm-fee-calculation.mdx
+++ b/overview/products/dlmm/dlmm-fee-calculation.mdx
@@ -32,7 +32,10 @@ $f_b = B \cdot s$ * 10^base_fee_power_factor
 
 </div>
 
-Base factor is the amplification to add to the bin step, to allow for adjustment of the pool base fees.
+Where:
+- **Base Factor** ($B$): An amplification to add to the bin step, to allow for adjustment of the pool base fees.
+- **Bin Step** ($s$): The price increment per bin, in basis points.
+- **Base Fee Power Factor**: An exponent that scales the base fee calculation. Default is 0 for most pools. Higher values increase the base fee exponentially.
 
 ## Variable Fee (Dynamic Fee)
 
@@ -199,7 +202,13 @@ You can see that the volatility accumulator is decreasing despite high frequency
 
 # DLMM Protocol Fees
 
-Protocol Fee is a percentage of the Dynamic Fee (total swap fee i.e. base \+ variable fee).
+Protocol Fee is a percentage of the total swap fee (base + variable fee).
 
-- Protocol Fee is 5% of the Dynamic Fee for all standard DLMM pools.
-- Protocol Fee is 20% of the Dynamic Fee for DLMM Launch Pools.
+- Protocol Fee is **5%** of the total swap fee for all standard DLMM pools.
+- Protocol Fee is **20%** of the total swap fee for DLMM Launch Pools.
+
+Protocol fees are configured via the `protocol_share` parameter on each pool's preset parameters (measured in basis points, max 1000 = 10%).
+
+<Warning>
+**Breaking change in v0.11.0:** Bin state no longer stores `amount_x_in` and `amount_y_in` fields. The `reward_per_token_stored` fields have been renamed to `function_bytes`. Integrations that index bin state directly must update their deserialization logic.
+</Warning>

--- a/overview/products/dlmm/dlmm-fee-calculation.mdx
+++ b/overview/products/dlmm/dlmm-fee-calculation.mdx
@@ -201,7 +201,5 @@ You can see that the volatility accumulator is decreasing despite high frequency
 
 Protocol Fee is a percentage of the Dynamic Fee (total swap fee i.e. base \+ variable fee).
 
-For our initial testing phase:
-
-- Protocol Fee is 5% of the Dynamic Fee for all standard DLMM Pools.
-- Protocol Fee is 20% of the Dynamic Fee for DLMM Bootstrapping Pools (Launch Pools).
+- Protocol Fee is 5% of the Dynamic Fee for all standard DLMM pools.
+- Protocol Fee is 20% of the Dynamic Fee for DLMM Launch Pools.

--- a/overview/products/dlmm/dlmm-fee-calculation.mdx
+++ b/overview/products/dlmm/dlmm-fee-calculation.mdx
@@ -28,7 +28,7 @@ The minimum fee charged per swap. Lower fee gets more volume but higher fee earn
 The base fee of a market is configured by the pool creator and determined by the base factor (B) and the bin step (s):
 
 <div align="center">
-$f_b = B \cdot s$ * 10^base_fee_power_factor
+$f_b = B \cdot s \cdot 10 \cdot 10^{\text{base\_fee\_power\_factor}}$
 
 </div>
 
@@ -71,6 +71,8 @@ The formula is:
 $f_v(k) = A(v_a(k) \cdot s)^2$
 
 </div>
+
+<Note>The on-chain computation uses ceiling division: it adds 99,999,999,999 before dividing by 100,000,000,000, ensuring the variable fee always rounds up.</Note>
 
 where:
 
@@ -207,7 +209,7 @@ Protocol Fee is a percentage of the total swap fee (base + variable fee).
 - Protocol Fee is **5%** of the total swap fee for all standard DLMM pools.
 - Protocol Fee is **20%** of the total swap fee for DLMM Launch Pools.
 
-Protocol fees are configured via the `protocol_share` parameter on each pool's preset parameters (measured in basis points, max 1000 = 10%).
+Protocol fees are configured via the `protocol_share` parameter on each pool's preset parameters (measured in basis points, max 2500 = 25%).
 
 <Warning>
 **Breaking change in v0.11.0:** Bin state no longer stores `amount_x_in` and `amount_y_in` fields. The `reward_per_token_stored` fields have been renamed to `function_bytes`. Integrations that index bin state directly must update their deserialization logic.

--- a/overview/products/dlmm/token-2022-extensions.mdx
+++ b/overview/products/dlmm/token-2022-extensions.mdx
@@ -17,6 +17,8 @@ The following extensions can be used permissionlessly with DLMM:
 - `TransferHook` - Custom transfer logic. Only when both `hook_program` and `hook_authority` are revoked
 - `MemoTransfer`
 
+<Note>`MemoTransfer` is an account-level extension, not a mint extension. It is applied to individual token accounts rather than to the mint itself.</Note>
+
 ---
 
 ## Permissioned Extensions


### PR DESCRIPTION
## Summary

Full documentation revamp for DAMM v2, DBC, and DLMM — bringing all three up to date with latest program versions.

## What Changed

### DAMM v2 (v0.2.0)
- **Compounding Fee Mode** (`collect_fee_mode = 2`): New pool mode where fees are collected in quote token and a configurable % is reinvested into reserves. Follows constant-product formula (no concentrated range). Documented in overview, fee calculation, formulas, and dev guide.
- **Pool Layout Versioning**: `layout_version` 0 vs 1 — v1 pools track `token_a_amount` / `token_b_amount` reserves
- **⚠️ Breaking: Partner Fee Removed** — `partner` field removed from Pool struct, `claim_partner_fee` endpoint removed, `EvtSwap2.partner_fee` replaced by `compounding_fee`. Total fee = `claiming_fee + compounding_fee`
- **Trading terminal integration** — Corrected fee formula, added fee mode reference table

### DBC (v0.1.10)
- **Compounding Fee Mode in Migration** — Config now supports `collectFeeMode: 2` + `compoundingFeeBps` for DAMM v2 graduated pools
- **Migration Simplification** — DBC → DAMM v2 migration no longer requires external vesting accounts (uses position itself, saves 2 accounts per tx)
- **Post-migration fee modes** — Reference table for trading terminal integrators

### DLMM (v0.11.0)
- **PositionV2** — Updated to document up to 1,400 bins per position
- **Pool types table** — All 4 pool types documented with reference table
- **Protocol fees** — Removed stale 'initial testing phase' language

## Files Changed
- `overview/products/damm-v2/` — 3 files
- `overview/products/dbc/` — 3 files
- `overview/products/dlmm/` — 1 file
- `developer-guide/guides/damm-v2/` — 1 file
- `developer-guide/guides/dbc/` — 2 files
- `developer-guide/guides/dlmm/` — 1 file
- `developer-guide/trading-terminals/` — 2 files

## Notes
- All operator/admin-only content excluded (internal tooling, not partner-facing)
- Breaking changes marked with `<Warning>` components
- New features marked with `<Note>` / `<Info>` components
- All code examples include imports and follow CLAUDE.md conventions