### PR TITLE
feat: add Bug Bounty section to Resources

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -660,6 +660,12 @@
               "resources/audits/dynamic-fee-sharing",
               "resources/audits/zap"
             ]
+          },
+          {
+            "group": "Bug Bounty",
+            "pages": [
+              "resources/bug-bounty/overview"
+            ]
           }
         ]
       },

--- a/resources/bug-bounty/overview.mdx
+++ b/resources/bug-bounty/overview.mdx
@@ -1,0 +1,14 @@
+---
+title: "Bug Bounty"
+description: "Help us secure Meteora by responsibly disclosing vulnerabilities. We work with OOO Security to manage our bug bounty program."
+---
+
+Meteora's bug bounty program is managed through [OOO Security](https://ooosec.com), covering vulnerabilities across our on-chain programs and protocol infrastructure.
+
+If you've found a security issue, please report it responsibly through the program — do not disclose publicly before it has been resolved.
+
+<CardGroup cols={1}>
+  <Card title="Meteora Bug Bounty Program" icon="shield-halved" href="https://ooosec.com/programs/meteora">
+    Report vulnerabilities and earn rewards for responsible disclosure. Covers DLMM, DAMM v1/v2, DBC, Alpha Vault, and other Meteora programs.
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## Summary

Adds a **Bug Bounty** section under the Resources tab in the docs.

### Changes
- New page: `resources/bug-bounty/overview.mdx` — description + card linking to the OOO Security program
- Updated `docs.json` — registered Bug Bounty group in the Resources tab navigation

### Preview

The Bug Bounty page includes:
- A short intro explaining Meteora uses OOO Security for the program
- A responsible disclosure note (don't go public before resolution)
- A card linking directly to https://ooosec.com/programs/meteora

Structured similarly to how other resources pages (Audits, Brand Kit) are organized.