### PR TITLE
docs: complete DAMM v1 product documentation

### DIFF
--- a/developer-guides/damm-v1/farming-sdk/farm-integration.mdx
+++ b/developer-guides/damm-v1/farming-sdk/farm-integration.mdx
@@ -3,7 +3,7 @@ title: Farm Integration
 description: DAMM v1 with Farm
 ---
 
-<Warning>DAMM v1 Pools with Farms are permissioned. Refer to the guide [here](/overview/products/damm-v1/pools-with-farms) on how to get a farming pool created.</Warning>
+<Warning>DAMM v1 Pools with Farms are permissioned. Refer to the guide [here](/legacy-products/damm-v1/pools-with-farms) on how to get a farming pool created.</Warning>
 
 # Code Examples
 

--- a/developer-guides/damm-v1/index.mdx
+++ b/developer-guides/damm-v1/index.mdx
@@ -5,15 +5,15 @@ title: Overview
 Before getting started building on DAMM v1, you should read the following resource to get a better understanding of how Meteora's DAMM v1 works:
 
 <CardGroup cols={2}>
-  <Card title="What's DAMM v1?" icon="question" iconType="solid" href="/overview/products/damm-v1/what-is-damm-v1">
+  <Card title="What's DAMM v1?" icon="question" iconType="solid" href="/legacy-products/damm-v1/what-is-damm-v1">
     DAMM v1 is Meteora's first AMM product that allows you to provide liquidity to a pool and earn yield from other landing protocols.
   </Card>
-  <Card title="Pools with Farms" icon="farm" iconType="solid" href="/overview/products/damm-v1/pools-with-farms">
+  <Card title="Pools with Farms" icon="farm" iconType="solid" href="/legacy-products/damm-v1/pools-with-farms">
     DAMM v1 pools with farms allows you to seed rewards to the pool such that liquidity providers can stake their LP tokens to earn the seeded rewards.
   </Card>
 </CardGroup>
 <CardGroup cols={1}>
-  <Card title="DAMM v1 Configs" icon="gear" iconType="solid" href="/developer-guide/guides/damm-v1/pool-fee-configs">
+  <Card title="DAMM v1 Configs" icon="gear" iconType="solid" href="/developer-guides/damm-v1/pool-fee-configs">
     Each DAMM v1 pool is a PDA of token mints + config. DAMM v1 configs are available on both mainnet and devnet.
   </Card>
 </CardGroup>
@@ -87,13 +87,13 @@ At Meteora, we’ve developed a `Node.js <> Typescript SDK` and `Rust CPI Exampl
 ## Official SDKs
 
 <CardGroup cols={2}>
-  <Card title="Typescript SDK" icon="node-js" iconType="solid" href="/developer-guide/guides/damm-v1/typescript-sdk/getting-started">
+  <Card title="Typescript SDK" icon="node-js" iconType="solid" href="/developer-guides/damm-v1/typescript-sdk/getting-started">
     Official Meteora DAMM v1 Typescript SDK
   </Card>
-  <Card title="Farming SDK" icon="node-js" iconType="solid" href="/developer-guide/guides/damm-v1/farming-sdk/getting-started">
+  <Card title="Farming SDK" icon="node-js" iconType="solid" href="/developer-guides/damm-v1/farming-sdk/getting-started">
     Official Meteora DAMM v1 Farming Typescript SDK
   </Card>
-  <Card title="Rust CPI Examples" icon="rust" iconType="solid" href="/developer-guide/guides/damm-v1/cpi/examples">
+  <Card title="Rust CPI Examples" icon="rust" iconType="solid" href="/developer-guides/damm-v1/cpi/examples">
     Official Meteora DAMM v1 Rust CPI Examples
   </Card>
 </CardGroup>

--- a/docs.json
+++ b/docs.json
@@ -194,12 +194,14 @@
                 "group": "DAMM v1",
                 "root": "legacy-products/damm-v1/what-is-damm-v1",
                 "pages": [
-                  "legacy-products/damm-v1/damm-v1-fee-and-apy-calculation",
                   "legacy-products/damm-v1/damm-v1-formulas",
                   "legacy-products/damm-v1/stable-pools",
                   "legacy-products/damm-v1/lst-pools",
                   "legacy-products/damm-v1/pools-with-farms",
-                  "legacy-products/damm-v1/additional-yield-from-dynamic-vaults"
+                  "legacy-products/damm-v1/additional-yield-from-dynamic-vaults",
+                  "legacy-products/damm-v1/damm-v1-fee-and-apy-calculation",
+                  "legacy-products/damm-v1/liquidity-locks",
+                  "legacy-products/damm-v1/pool-design-guide"
                 ]
               },
               {

--- a/get-started/index.mdx
+++ b/get-started/index.mdx
@@ -104,7 +104,7 @@ The same battle-tested infrastructure powering meteora.ag’s DLMM, DAMM, and Dy
   <Card title="Build with Zap" icon="bolt-lightning" iconType="solid" href="/developer-guide/guides/zap/overview">
     Combine claims and Jupiter swaps in one transaction across DAMM v2 and DLMM pools.
   </Card>
-  <Card title="Build with DAMM v1" icon="infinity" iconType="solid" href="/developer-guide/guides/damm-v1/overview">
+  <Card title="Build with DAMM v1" icon="infinity" iconType="solid" href="/developer-guides/damm-v1">
     Build with the legacy infinite-range AMM that contains integrated lending yield.
   </Card>
   <Card title="Build with Dynamic Vault" icon="vault" iconType="solid" href="/developer-guide/guides/dynamic-vault/overview">

--- a/legacy-products/damm-v1/additional-yield-from-dynamic-vaults.mdx
+++ b/legacy-products/damm-v1/additional-yield-from-dynamic-vaults.mdx
@@ -1,24 +1,115 @@
 ---
 title: "Additional Yield From Dynamic Vaults"
-description: "How DAMM v1 earns additional yield by deploying idle liquidity to Dynamic Vaults, which allocate capital across lending protocols to maximize returns."
+sidebarTitle: "Dynamic Vault Yield"
+description: "Learn how DAMM v1 pools can earn additional yield by routing eligible idle liquidity through Meteora Dynamic Vaults."
+llmsDescription: "Product documentation for DAMM v1 Dynamic Vault yield, explaining vault-backed pool liquidity, idle liquidity allocation, strategies, reserve liquidity, LP share value, virtual price, locked profit, vault risk, and why vault yield complements swap fees and farming rewards."
 ---
 
-# What are Dynamic Vaults?
+One of DAMM v1's defining features is that pool liquidity can sit on top of Dynamic Vaults. Instead of leaving every token idle inside a standard pool account, eligible DAMM v1 assets can be connected to vaults that allocate unused liquidity into supported external strategies.
 
-[Dynamic Vaults](/overview/other-products/dynamic-vault/what-is-dynamic-vault) operate as a lending aggregator that allocates capital across multiple lending protocols on Solana. We utilize an off-chain keeper called [Hermes](/overview/other-products/dynamic-vault/what-is-hermes) which constantly monitors all lending pools every minute and rebalances allocations to optimize yields and reduce risk.
+For LPs, this creates an additional return layer. A DAMM v1 pool can earn swap fees from trading activity while eligible idle assets may also earn lending yield through the Dynamic Vault layer.
 
-While there is risk in lending, our Dynamic Vaults [mitigate that risk](/overview/other-products/dynamic-vault/risk-management) by constantly monitoring lending pool utilization rates and automatically withdrawing funds whenever risk thresholds are hit. Additionally, only a maximum of 30% is ever allocated to any single protocol.
+## What Dynamic Vaults do
 
-And our Dynamic Vaults have already been battle-tested with several real-life events: The USDC depeg in early March and the USDH exploit late last year. In both cases, Hermes was able to automatically detect and withdraw all funds safely.
+Dynamic Vaults are Meteora's capital allocation layer. A vault holds a supported token, keeps part of the liquidity available in reserve, and can allocate part of the liquidity into approved strategies.
 
-# Additional Yield
+A vault tracks:
 
-For DAMM v1 Pools paired with USDC/SOL/USDT, a portion of unused USDC/SOL/USDT liquidity gets dynamically loaned out to external lending platforms (e.g. Kamino, Marginfi, Save (Solend)) to generate extra yield for LPs, via our Dynamic Vaults. 
+- The token it supports.
+- The total amount of that token controlled by the vault.
+- The reserve token account available for immediate liquidity.
+- Approved strategies that can receive allocations.
+- Vault LP supply, which represents shares of the vault.
+- Locked profit accounting, which smooths newly reported gains over time.
 
-This benefit applies to all Dynamic AMM Pools on Meteora that have USDC/SOL/USDT in the pair.
+DAMM v1 pools use vault LP positions to represent the pool's ownership of each token-side vault.
 
-- As such, a portion of USDC/SOL/USDT liquidity may be utilized in external lending platforms, while the rest remain in the Dynamic Vault Reserve to support sudden withdrawals by LPs. This can be viewed in the "Shared Vault Balance" of the pool account.
+## How this connects to DAMM v1
 
-- In an event where LPs have a liquidity position that is much larger than what is in the Dynamic Vault Reserve, and want to immediately withdraw all liquidity (that has USDC/SOL/USDT), they can withdraw liquidity in smaller sizes a few times or reach out to the team.
+A DAMM v1 pool has two token sides. Each side points to a Dynamic Vault. When the pool needs to understand its balances, it converts its vault LP holdings back into the current underlying token amounts.
 
-- Yield earned from Dynamic Vaults is shown on the Dynamic AMM Pool UI as "24h Yield".
+That means the AMM can continue to price swaps, deposits, withdrawals, and LP share value while the vault layer manages eligible idle liquidity behind the scenes.
+
+<Info>
+  In DAMM v1 source, the pool stores vault accounts and vault LP token accounts for both token sides. This is the core reason DAMM v1 is described as an AMM built on Dynamic Vault infrastructure.
+</Info>
+
+## Why this creates additional yield
+
+In a normal AMM, unused liquidity simply waits for the next trade. In a DAMM v1 pool with supported vault assets, a portion of idle liquidity can be allocated to external yield sources.
+
+The return stack becomes:
+
+1. Traders pay swap fees.
+2. LP token value can rise as fees remain in the pool.
+3. Eligible vault assets may earn strategy yield.
+4. Vault yield can increase the value backing the pool's vault LP positions.
+5. LPs benefit through pool share value and virtual price growth.
+
+This helps reduce reliance on constant liquidity mining emissions. A pool can be more attractive to LPs even when trading volume is uneven or reward campaigns are not active.
+
+## Reserve liquidity and withdrawals
+
+Dynamic Vaults do not send every token into a strategy. A portion of liquidity can remain in the vault reserve to support normal pool operations.
+
+This reserve matters because DAMM v1 pools still need liquidity for:
+
+- Swaps.
+- Balanced withdrawals.
+- Single-sided withdrawals where supported.
+- LP operations and pool accounting.
+
+If a very large withdrawal exceeds immediately available reserve liquidity for a vault-backed asset, the user experience may require smaller withdrawals or operational support while liquidity is moved back from strategies.
+
+<Warning>
+  Vault-backed yield improves capital productivity, but it is not the same as instant idle cash. Strategy allocations can affect how much liquidity is immediately available in the reserve at a given moment.
+</Warning>
+
+## Locked profit and smoother share value
+
+Dynamic Vaults use locked profit accounting. When a vault reports gains, those gains are not necessarily made fully available to new deposits immediately. Instead, profit can unlock over time.
+
+The product reason is fairness. Without smoothing, someone could deposit immediately before a gain is reported and withdraw after capturing value they did not help earn. Locked profit helps reduce that kind of timing advantage.
+
+For LPs, this means vault yield may show up as gradual share value improvement rather than an instant jump.
+
+## Where LPs see the impact
+
+DAMM v1 LPs typically experience vault yield through pool performance metrics, such as virtual price growth or displayed yield metrics. The exact UI label can vary, but the product idea is consistent: vault yield increases the underlying value backing pool shares when strategies perform positively.
+
+A simplified virtual price view is:
+
+```math
+\text{virtual price} = \frac{\text{total pool value}}{\text{LP token supply}}
+```
+
+If pool value rises from fees or vault yield while LP supply stays the same, virtual price increases.
+
+## Eligible assets
+
+Dynamic Vault yield depends on vault support. Historically, DAMM v1 vault yield has been most relevant for major liquid assets such as USDC, USDT, and SOL, where external lending or liquidity strategies exist.
+
+Not every token pair can earn vault yield. A long-tail token may still use DAMM v1's AMM design, but the additional vault yield layer depends on whether the token side has a supported Dynamic Vault strategy.
+
+## Risk considerations
+
+Dynamic Vault yield introduces additional risk considerations beyond basic AMM liquidity:
+
+- External strategy risk.
+- Lending market risk.
+- Smart contract risk.
+- Liquidity availability risk.
+- Operational and keeper risk.
+- Changes in external yield rates.
+
+Meteora's vault design includes controls such as approved strategy lists, reserve management, operators, and rebalancing, but LPs should still treat vault yield as a DeFi strategy exposure.
+
+## How to think about vault yield
+
+Dynamic Vault yield is best understood as a baseline capital productivity layer. It does not replace trading volume, and it does not replace farms. Instead, it makes DAMM v1 pools more durable by giving eligible idle assets something productive to do between trades.
+
+For a strong DAMM v1 pool, the ideal return mix is:
+
+- **Organic fees** from useful trading volume.
+- **Vault yield** from eligible idle assets.
+- **Targeted farms** for strategic growth periods.

--- a/legacy-products/damm-v1/damm-v1-fee-and-apy-calculation.mdx
+++ b/legacy-products/damm-v1/damm-v1-fee-and-apy-calculation.mdx
@@ -1,51 +1,146 @@
 ---
 title: "DAMM v1 Fee and APY Calculation"
-description: "How trading fees and APY are calculated in DAMM v1 pools, including the contribution of vault yield on top of swap fee earnings."
+sidebarTitle: "Fee and APY Calculation"
+description: "How DAMM v1 trading fees, protocol fees, base APY, fee-over-TVL, Dynamic Vault yield, and farm APR are interpreted for LPs."
+llmsDescription: "Product explanation of DAMM v1 fee and APY calculation, covering swap fees, protocol fees, LP fee value, virtual price growth, base APY, 365-day fee over TVL, farm APR, Dynamic Vault yield, and caveats when comparing displayed returns."
 ---
 
-In order to enhance transparency for our LPs concerning the APY associated with their deposited assets, we compute and display various information, for example: Liquidity Provider Fee, Protocol Fee, 365d Yield/TVL, and LM rewards APR.
+DAMM v1 LP returns can come from several sources, so APY needs to be read carefully. A pool may show fee performance, base APY, Dynamic Vault yield, and farming incentives. These are related, but they are not the same thing.
 
-# Total Trading Fee
-The amount of fees charged on each trade that goes to liquidity providers (LPs).
+This page explains how to think about the metrics at a product level.
 
-# Protocol Fee
-The amount of fees charged on each trade that goes to the protocol. Protocol Fee is a % of the LP Fee. 
+## Total trading fee
 
-For our initial testing phase, Protocol Fee has been set as 20% of the LP Fee, for all volatile Dynamic AMM Pools.
-
-# Base APY 
-The base APY offered is subject to variation and is based on the prevailing trading activity and yield obtained from lending platforms. The calculation of APY is contingent on the increase in virtual price over a specific time period.
+Every swap can charge a trading fee. The trading fee is calculated from the input amount:
 
 ```math
-\text{base APY} = \left(\left(\frac{\text{Virtual Price 2}}{\text{Virtual Price 1}}\right)^{\frac{1 \text{ year}}{\text{Timeframe}}} - 1\right) \times 100
+\text{trading fee} = \text{input amount} \times \frac{\text{trade fee numerator}}{\text{trade fee denominator}}
+```
+
+The LP-relevant portion of the fee remains with the pool and increases the value backing LP tokens. In practice, LPs do not need to manually collect this fee from a DAMM v1 LP-token pool. The fee is reflected in pool share value.
+
+## Protocol fee
+
+DAMM v1 can also charge a protocol fee:
+
+```math
+\text{protocol fee} = \text{input amount} \times \frac{\text{protocol fee numerator}}{\text{protocol fee denominator}}
+```
+
+The protocol fee is separate from the LP value. Depending on pool configuration, protocol and partner fee settings can determine how swap fees are split.
+
+For LPs, the key question is: what portion of the trading fee remains in the pool and increases LP token value?
+
+## Host and partner fee routing
+
+DAMM v1 also has fee routing logic for host or partner fee arrangements. Product-wise, this allows integrations or partners to receive a configured share of eligible protocol-side fees.
+
+This does not change the core LP concept: LPs evaluate the net value accruing to the pool after applicable fee splits.
+
+## Base APY
+
+Base APY measures how much the value of a pool share has increased over a period, annualized.
+
+```math
+\text{base APY} = \left(\left(\frac{\text{Virtual Price}_{2}}{\text{Virtual Price}_{1}}\right)^{\frac{\text{1 year}}{\text{timeframe}}} - 1\right) \times 100
 ```
 
 Where:
-- **Virtual Price 2**: Latest Virtual Price value
-- **Virtual Price 1**: Previous Virtual Price value in the last 24 Hours
-- **Timeframe**: Time difference between Virtual Price 1 and Virtual Price 2 (in seconds)
 
-> **Note**: The Virtual Price represents the value of your pool share and is determined by dividing the pool's total value by the number of LP tokens (VP = pool_value / LP token). The pool's value rises as a result of a swap fee being charged on each trade or when assets deposited in lending pools generate lending yield. This increase in pool value corresponds to a rise in the Virtual Price.
+- `Virtual Price 1` is the older virtual price.
+- `Virtual Price 2` is the newer virtual price.
+- `timeframe` is the measurement period.
 
-# 365d Yield/TVL
-The ratio of the aggregate swap fees accrued over a 1-year period to the total liquidity available in the pool represents the efficiency metric that informs LPs which pool generates the most trading fees. This data empowers LPs with valuable insights into pool performance.
+Virtual price is:
 
 ```math
-\text{1 year fee/TVL} = \frac{\text{24 hour fee} \times 365}{\text{Total Liquidity of pool}}
+\text{virtual price} = \frac{\text{total pool value}}{\text{LP token supply}}
+```
+
+Virtual price can rise because of:
+
+- Swap fees.
+- Eligible Dynamic Vault yield.
+- Any value that increases pool assets relative to LP token supply.
+
+<Note>
+  Base APY is backward-looking. It annualizes what happened during a measurement window. It is not a promise that the same return will continue.
+</Note>
+
+## 365-day fee over TVL
+
+This metric annualizes recent swap fee generation against pool liquidity:
+
+```math
+\text{365d fee / TVL} = \frac{\text{24h fees} \times 365}{\text{pool TVL}}
 ```
 
 Where:
-- 24 hour fee: Swap fee generated in the last 24 hour in $
-- Total Liquidity of pool: Total value of the assets stored in the AMM pool in $
 
-# Liquidity Mining (LM) APR
-This refers to the APR that is calculated based on the rewards provided by the team or partner protocols through Liquidity Mining (LM), such as ABR, LDO rewards, etc.
+- `24h fees` is the fee value generated over the last 24 hours.
+- `pool TVL` is the current value of liquidity in the pool.
+
+This is useful for comparing how efficiently different pools are generating trading fees. A smaller pool with heavy volume may show a high fee-over-TVL number. A large pool with quiet volume may show a lower number.
+
+## Dynamic Vault yield
+
+Some DAMM v1 pools can earn additional yield through Dynamic Vaults. This yield comes from eligible idle assets being allocated to supported external strategies.
+
+Vault yield can contribute to base APY because it can increase the value backing the pool's vault LP positions. The important distinction:
+
+- **Trading fee yield** comes from swaps.
+- **Vault yield** comes from eligible vault strategies.
+- **Farm APR** comes from reward token emissions.
+
+These can all appear in the LP return profile, but each has different drivers and risks.
+
+## Farm APR
+
+Liquidity mining APR estimates the annualized value of farm rewards relative to farm TVL:
 
 ```math
-\text{LM APR} = \left(\left(1 + \frac{\text{Farm Reward per day}}{\text{Farm TVL}}\right)^{365} - 1\right) \times 100
+\text{LM APR} = \left(\left(1 + \frac{\text{farm reward per day}}{\text{farm TVL}}\right)^{365} - 1\right) \times 100
 ```
 
 Where:
-- **Farm reward per day**: Token reward per day × token reward USD rate
-- **Farm TVL**: (Pool LP staked / Pool LP supply) × Pool TVL
-- **Pool TVL**: Pool token A × token A USD rate + Pool token B × token B USD rate
+
+- `farm reward per day` is the daily value of reward emissions.
+- `farm TVL` is the value of LP tokens staked in the farm.
+
+Farm APR is only relevant if LPs stake LP tokens in the farm. LP tokens sitting unstaked in a wallet still own pool liquidity, but they do not earn farm rewards from that farm.
+
+## Reading a DAMM v1 pool return stack
+
+When comparing DAMM v1 pools, break the displayed return into layers:
+
+### 1. Organic trading demand
+
+Does the pair have real swap volume? High trading volume can generate sustainable fees.
+
+### 2. Pool depth
+
+How much TVL is competing for those fees? More TVL can reduce slippage, but it also spreads fee revenue across more LP capital.
+
+### 3. Vault yield eligibility
+
+Does one side or both sides of the pool connect to Dynamic Vault yield? If yes, what are the supported assets and risk assumptions?
+
+### 4. Farm incentives
+
+Is there an active farm? What reward token is emitted? How long does it last? How much LP liquidity is staked?
+
+### 5. Asset risk
+
+A high displayed APY does not offset all asset risk. LPs still face price movement, depeg risk, smart contract risk, and incentive changes.
+
+## Practical example
+
+A DAMM v1 stablecoin pool might have:
+
+- Low but steady trading fees.
+- Eligible Dynamic Vault yield on one or both stable assets.
+- A temporary partner farm.
+
+The combined displayed return may look attractive, but each component behaves differently. Trading fees depend on volume. Vault yield depends on external strategy rates and risk. Farm APR depends on reward funding and how many LP tokens are staked.
+
+A healthy LP decision looks at all three instead of chasing the largest number on the screen.

--- a/legacy-products/damm-v1/damm-v1-formulas.mdx
+++ b/legacy-products/damm-v1/damm-v1-formulas.mdx
@@ -1,51 +1,217 @@
 ---
-title: DAMM v1 Formulas
-description: "Mathematical formulas for the DAMM v1 constant-product AMM: price impact, liquidity provision, and fee calculations."
+title: "DAMM v1 Formulas"
+sidebarTitle: "Formulas"
+description: "Understand the product math behind DAMM v1 constant-product pools, stable pools, fees, LP shares, virtual price, vault yield, and farming rewards."
+llmsDescription: "Explains DAMM v1 formulas in non-technical product language, covering constant-product x*y=k, StableSwap amplification, depeg-aware LST pools, LP share minting, virtual price, trading fee, protocol fee, Dynamic Vault share value, APY, farm APR, and reward-per-token distribution."
 ---
 
-DAMM v1 is a traditional full-range liquidity AMM with multiple curve support.
+DAMM v1 is a full-range AMM with two main curve designs: constant-product pools for volatile assets, and stable-swap pools for assets that should trade close together. The formulas below explain how the product behaves without turning this page into an integration guide.
 
-# Constant Product Curve (xy = k)
+## Constant-product pools
 
-The constant product formula maintains liquidity invariance through the following relationships:
-
-## Invariant Formula
-```math
-k = \text{token}_a \times \text{token}_b
-```
-
-## Liquidity Invariant (D)
-```math
-D = \sqrt{\text{token}_a \times \text{token}_b}
-```
-
-## Stable Swap Curve (StableSwap)
-
-Implements Curve Finance's StableSwap algorithm via Saber StableSwap.
-
-## Core StableSwap Invariant
+The basic volatile-pool formula is:
 
 ```math
-A \cdot n^n \cdot \sum_{i} x_i + D = A \cdot n^n \cdot D + \frac{D^{n+1}}{n^n \cdot \prod_{i} x_i}
+x \times y = k
 ```
 
-**Where:**
-- `A` = amplification coefficient
-- `n` = number of tokens (2 for pairs)
-- `x_i` = token amounts
-- `D` = invariant
+Where:
 
----
+- `x` is the amount of token A in the pool.
+- `y` is the amount of token B in the pool.
+- `k` is the pool invariant.
 
-# Fee Calculation Formulas
+When a trader adds token A and removes token B, `x` rises and `y` falls. The pool reprices the trade so the relationship between both reserves stays balanced.
 
-## Trading Fees
+For users, this means:
 
-### Base Trading Fee
+- Larger pools usually create lower price impact.
+- Larger trades move price more than smaller trades.
+- The pool supports a continuous price range from very low to very high prices.
+
+## Constant-product swap output
+
+Before fees, a simplified output calculation looks like this:
 
 ```math
-\text{fee} = \frac{\text{token\_amount} \times \text{fee\_numerator}}{\text{fee\_denominator}}
+\text{new source reserve} = \text{source reserve} + \text{input amount}
 ```
 
-**Where:**
-- `fee_denominator` = 100,000
+```math
+\text{new destination reserve} = \frac{k}{\text{new source reserve}}
+```
+
+```math
+\text{output amount} = \text{destination reserve} - \text{new destination reserve}
+```
+
+DAMM v1 uses safe on-chain integer math, so tiny rounding differences can happen at the smallest token unit. Product-wise, the idea is straightforward: every buy makes the bought token scarcer in the pool, which raises its price for the next trade.
+
+## Stable pools
+
+Stable pools are designed for assets that should trade near a target relationship, such as USDC/USDT or SOL/LST markets. Instead of using only `x × y = k`, DAMM v1 stable pools use a StableSwap-style invariant with an amplification factor.
+
+A simplified StableSwap invariant can be represented as:
+
+```math
+A \cdot n^n \cdot \sum x_i + D = A \cdot n^n \cdot D + \frac{D^{n+1}}{n^n \cdot \prod x_i}
+```
+
+Where:
+
+- `A` is the amplification factor.
+- `n` is the number of assets in the pool. DAMM v1 pools are two-token pools.
+- `x_i` represents normalized token balances.
+- `D` is the stable pool invariant.
+
+In plain English: amplification makes the pool behave as if it has deeper liquidity near the target price. That helps reduce slippage when both assets are close to their expected relationship.
+
+<Note>
+  A higher amplification factor concentrates more liquidity near the target relationship, but it also makes the pool less forgiving when the assets move far away from that relationship.
+</Note>
+
+## Token normalization
+
+Stable pools normalize token amounts before applying the curve. This matters when two tokens have different decimals.
+
+```math
+\text{normalized amount} = \text{raw amount} \times \text{token multiplier}
+```
+
+The goal is to compare both assets on a consistent precision scale before calculating swaps, deposits, and withdrawals.
+
+## LST depeg adjustment
+
+For supported LST pools, DAMM v1 can account for the changing value of the staking token relative to SOL. The program stores and updates a base virtual price for the LST side of the pool.
+
+Conceptually:
+
+```math
+\text{pegged LST amount} = \text{LST amount} \times \text{LST virtual price}
+```
+
+This lets the pool reason about an LST's value instead of treating one LST as always equal to one SOL. That is important because LSTs generally increase in SOL terms as staking rewards accrue.
+
+## LP share ownership
+
+LP tokens represent a share of the pool. A simplified LP ownership formula is:
+
+```math
+\text{LP ownership share} = \frac{\text{LP tokens held}}{\text{total LP token supply}}
+```
+
+The value of that share depends on the pool's underlying token value:
+
+```math
+\text{LP share value} = \text{ownership share} \times \text{total pool value}
+```
+
+DAMM v1 pools route token balances through Dynamic Vaults. That means the pool often measures its token A and token B totals by converting vault LP balances back into underlying token amounts.
+
+## Virtual price
+
+Virtual price is a useful way to understand whether a pool share is becoming more valuable over time.
+
+```math
+\text{virtual price} = \frac{\text{total pool value}}{\text{LP token supply}}
+```
+
+Virtual price can rise when:
+
+- Swaps generate fees that remain in the pool.
+- Eligible vault assets earn yield.
+- Rewards or yield increase the underlying value backing pool shares.
+
+For LPs, virtual price is the bridge between pool activity and share value.
+
+## Trading fees
+
+DAMM v1 charges trading fees on swaps. A simplified fee calculation is:
+
+```math
+\text{trading fee} = \text{input amount} \times \frac{\text{trade fee numerator}}{\text{trade fee denominator}}
+```
+
+DAMM v1 also supports protocol fees:
+
+```math
+\text{protocol fee} = \text{input amount} \times \frac{\text{protocol fee numerator}}{\text{protocol fee denominator}}
+```
+
+The remaining fee value benefits LPs because it stays with the pool and increases the value backing LP tokens.
+
+<Info>
+  DAMM v1's fee math has a minimum-fee behavior for non-zero trades when the calculated fee would otherwise round down to zero. This prevents tiny trades from bypassing fees entirely.
+</Info>
+
+## Base APY from virtual price
+
+DAMM v1 APY can be estimated from virtual price growth over a time window:
+
+```math
+\text{base APY} = \left(\left(\frac{\text{Virtual Price}_{2}}{\text{Virtual Price}_{1}}\right)^{\frac{\text{1 year}}{\text{timeframe}}} - 1\right) \times 100
+```
+
+Where:
+
+- `Virtual Price 1` is the earlier virtual price.
+- `Virtual Price 2` is the later virtual price.
+- `timeframe` is the time between the two measurements.
+
+This base APY can include the effect of trading fees and eligible vault yield because both can increase the value backing each LP token.
+
+## 365-day fee over TVL
+
+A simple fee efficiency metric annualizes recent swap fees against pool liquidity:
+
+```math
+\text{365d fee / TVL} = \frac{\text{24h fees} \times 365}{\text{pool TVL}}
+```
+
+This helps LPs compare how much fee activity a pool is generating relative to the amount of liquidity supplied.
+
+## Farm rewards
+
+DAMM v1 farms distribute reward tokens to staked LP tokens over time. A simplified reward rate is:
+
+```math
+\text{reward rate} = \frac{\text{funded reward amount}}{\text{reward duration}}
+```
+
+Reward per staked LP token grows as time passes:
+
+```math
+\text{reward per token} = \text{previous reward per token} + \frac{\text{elapsed time} \times \text{reward rate}}{\text{total staked LP tokens}}
+```
+
+A user's pending reward is based on their staked balance:
+
+```math
+\text{user reward} = \text{staked LP tokens} \times \text{reward per token since last update}
+```
+
+DAMM v1 farms can support up to two reward tokens. If the pool has no staked LP tokens during part of a reward period, reward accounting waits until there is active stake instead of distributing to nobody.
+
+## LM APR
+
+Liquidity mining APR estimates the annualized value of farm emissions relative to farm TVL:
+
+```math
+\text{LM APR} = \left(\left(1 + \frac{\text{farm reward per day}}{\text{farm TVL}}\right)^{365} - 1\right) \times 100
+```
+
+Where:
+
+- `farm reward per day` is the daily token emission value in USD.
+- `farm TVL` is the value of LP tokens staked in the farm.
+- `pool TVL` is the value of all token A and token B liquidity in the pool.
+
+## The product takeaway
+
+DAMM v1 is not just one formula. It is a stack:
+
+- Curve math determines how swaps price trades.
+- Fee math determines how value is captured from volume.
+- Vault math determines how eligible idle assets can earn yield.
+- Farm math determines how external incentives are distributed.
+- Virtual price connects those value sources back to LP share value.

--- a/legacy-products/damm-v1/liquidity-locks.mdx
+++ b/legacy-products/damm-v1/liquidity-locks.mdx
@@ -1,0 +1,95 @@
+---
+title: "Liquidity Locks"
+description: "Understand how DAMM v1 liquidity locks let LP tokens be locked while the underlying liquidity remains in the pool."
+llmsDescription: "Product documentation for DAMM v1 liquidity locks, explaining LP token escrow, total locked LP, community confidence, fee and vault yield exposure, locked liquidity tradeoffs, and how lock signals differ from risk removal."
+---
+
+DAMM v1 supports liquidity locks. A liquidity lock moves LP tokens into an escrow account so the liquidity remains committed to the pool instead of being freely withdrawable by the owner.
+
+For projects and communities, locked liquidity is a trust signal. It shows that a portion of the pool's liquidity is intended to stay in place, supporting trading depth and reducing concerns that liquidity will be suddenly removed.
+
+## What gets locked?
+
+In DAMM v1, LP tokens represent ownership of the pool. Locking liquidity means locking those LP tokens.
+
+The underlying pool assets remain inside the DAMM v1 pool and its connected vault accounts. Traders can still swap against the liquidity. The pool can still earn fees. Eligible assets can still participate in Dynamic Vault behavior where supported.
+
+The lock is on the owner's ability to freely redeem those LP tokens for underlying assets.
+
+## Why projects lock liquidity
+
+Projects use locked liquidity to send a clear market signal:
+
+- The team is committing pool depth for the long term.
+- Traders can see that liquidity is less likely to disappear suddenly.
+- The community has more confidence in the pool's durability.
+- Launch partners can verify that a liquidity commitment exists.
+
+This is especially important for long-tail tokens and community markets where trust is part of the product experience.
+
+## What LPs still earn
+
+Locked LP tokens still represent pool ownership. Because the liquidity remains in the pool, it can continue to participate in the pool's economics.
+
+Depending on pool configuration, locked liquidity can remain exposed to:
+
+- Trading fee value accrual.
+- Dynamic Vault yield on eligible assets.
+- Pool value changes caused by price movement.
+- Any other pool-level effects that change LP share value.
+
+<Note>
+  A lock does not make liquidity risk-free. It changes withdrawal control. The locked LP position still has exposure to the underlying pool assets and DeFi risks.
+</Note>
+
+## How the lock works conceptually
+
+<Steps>
+  <Step title="LP provides liquidity">
+    The LP deposits assets into a DAMM v1 pool and receives LP tokens.
+  </Step>
+  <Step title="LP tokens are moved to escrow">
+    The lock action transfers LP tokens into a lock escrow account and records the locked amount.
+  </Step>
+  <Step title="Pool tracks locked LP supply">
+    DAMM v1 tracks total locked LP tokens for the pool, making locked liquidity visible at the pool level.
+  </Step>
+  <Step title="Liquidity remains active">
+    The underlying liquidity continues supporting swaps because the pool assets were not withdrawn.
+  </Step>
+</Steps>
+
+## Locked liquidity vs farmed liquidity
+
+Locked liquidity and farmed liquidity are different.
+
+- **Locked liquidity** is about commitment. LP tokens are escrowed to restrict withdrawal.
+- **Farmed liquidity** is about incentives. LP tokens are staked to earn reward emissions.
+
+A pool can have both, but they serve different product goals. Locking builds confidence. Farming attracts or retains liquidity through rewards.
+
+## What locks do not solve
+
+Liquidity locks are useful, but they are not a complete safety guarantee.
+
+They do not remove:
+
+- Token price risk.
+- Smart contract risk.
+- Dynamic Vault strategy risk.
+- Depeg risk for stable or LST pairs.
+- The possibility that unlocked liquidity leaves.
+- The need to evaluate token ownership and supply distribution.
+
+A lock is one positive signal among many. Users should still evaluate the full pool and project context.
+
+## When to use a lock
+
+A DAMM v1 liquidity lock is useful when:
+
+- A project wants to show long-term liquidity commitment.
+- A launch pool needs stronger community confidence.
+- A partner or community expects liquidity to remain available.
+- The team wants pool depth to continue supporting trading even after launch.
+
+For mature pools, locks can also help distinguish strategic liquidity from short-term mercenary liquidity.

--- a/legacy-products/damm-v1/lst-pools.mdx
+++ b/legacy-products/damm-v1/lst-pools.mdx
@@ -1,28 +1,94 @@
 ---
 title: "LST Pools"
-description: "Liquid Staking Token (LST) pools in DAMM v1 — purpose-built for SOL/LST pairs with stable pricing that accounts for the staking rate."
+description: "Learn how DAMM v1 LST pools support SOL/LST liquidity with stable-pool pricing, depeg-aware value tracking, and additional yield opportunities."
+llmsDescription: "Product documentation for DAMM v1 LST pools, covering SOL/LST pool design, LST virtual price tracking, depeg-aware stable pools, LP benefits, LST protocol benefits, Dynamic Vault yield, and when LST pools are useful."
 ---
 
-With Dynamic LST Pools, we aim to greatly enhance the options for both LST creators, liquidity providers, and users to grow liquidity and promote the adoption of liquid staking tokens on Solana.
+DAMM v1 LST pools are stable-style pools built for liquid staking token markets. They help users swap between SOL and supported LSTs while giving LST protocols a way to build deeper, more sustainable liquidity.
 
-Growing LST adoption has the potential to solve some of the major blockers in Solana DeFi. There is ~$9.5B worth of capital (383M SOL) in directly staked SOL with less than 3% in LSTs. Growing LST adoption would help unlock that capital and put it to work in Solana DeFi dramatically increasing liquidity, volume, and the number of tradable assets.
+An LST, or liquid staking token, represents staked SOL plus accumulated staking rewards. Because staking rewards accrue over time, many LSTs are designed to become worth slightly more SOL over time. That makes a simple 1:1 pool incomplete: the pool needs to understand that the LST side may appreciate.
 
-# What are DAMM v1 LST pools?
+## Why LST pools exist
 
-The price of LSTs is constantly increasing with respect to the staked token as staking rewards get distributed every epoch. This price increase leads to impermanent loss (IL) for LPs in any xSOL/SOL pool. Our Dynamic LST pools are stable and mitigate IL from this price increase by continually tracking the price of an xSOL token directly from the LST’s on-chain program. By avoiding the use of price oracles, we remove a dependency and a potential exploit vector.
+Solana has a large amount of directly staked SOL. Liquid staking helps make that capital usable across DeFi, but LST adoption depends on liquidity. Users need to enter and exit LSTs with low slippage. Protocols need enough market depth for their token to be useful across wallets, aggregators, lending markets, and structured products.
 
-# How does it work?
+DAMM v1 LST pools were built to support that market structure:
 
-For liquidity providers (LPs), this means you can deposit and withdraw at any time without having to worry about IL or whether the APY you are earning is enough to offset the IL.
+- Users get a swap venue between SOL and LSTs.
+- LPs can provide passive liquidity without managing active ranges.
+- LST protocols can grow liquidity without relying only on emissions.
+- Eligible assets can earn additional yield through Dynamic Vaults.
 
-Additionally, our Dynamic LST Pools utilize the stable curve AMM model in order to concentrate the liquidity to offer low-slippage trades and increase the volume capture from swap aggregators like Jupiter. LPs benefit from the increased volume with better revenue from fees. And unlike concentrated liquidity automated market makers (CLMMs), an LP does not have to constantly manage their liquidity positions.
+## The core problem: LSTs appreciate
 
-A major problem for growing liquidity for any token is an overreliance on farming rewards. Often times it means having to utilize aggressive token emissions or maintain farming rewards over a longer period of time to maintain a certain level of liquidity. You generally see this if trading fees cannot support the liquidity depth in an AMM pool.
+In a standard AMM, a SOL/LST pool can create impermanent loss for LPs if the LST reliably appreciates against SOL. The pool may treat the assets as if they should remain 1:1 even though staking rewards gradually change the fair relationship.
 
-Our Dynamic LST Pools utilize Meteora’s Dynamic Vaults to provide a more sustainable way to grow and retain liquidity by lending out the idle capital in the pool to earn an additional yield. This allows LPs to continuously earn lending yield even when trading volume dips or farming rewards end.
+DAMM v1 addresses this with a depeg-aware stable pool design. The pool can update a base virtual price for the LST side and use that value when calculating stable-swap balances.
 
-# So what does this mean for liquid staking protocols?
+Conceptually:
 
-Our Dynamic LST Pools powered by [Dynamic Vaults](/overview/other-products/dynamic-vault/what-is-dynamic-vault) offer a more sustainable way to grow liquidity for your LST. You are less reliant on farming rewards to grow your liquidity and LPs are less likely to leave when your farming rewards end. Additionally, you’ll be able to support a deeper liquidity depth than your volume/fees may currently allow. This can be crucially important in the early days when you are looking to build up the trading volumes for your LST.
+```math
+\text{LST value used by the pool} = \text{LST amount} \times \text{LST virtual price}
+```
 
-We’ve been working hard to support our partners Marinade Finance, Jito Labs, and SolBlaze in helping them achieve their specific goals for their LST pools and will be providing that same level of support for any project that wants to launch a Dynamic LST Pool with us.
+This lets the pool price swaps based on the LST's underlying value rather than assuming one LST is always equal to one SOL.
+
+<Info>
+  DAMM v1 includes depeg handling for supported LST designs, including integrations around staking-pool style virtual price data.
+</Info>
+
+## How DAMM v1 LST pools work
+
+A DAMM v1 LST pool combines three ideas:
+
+1. **Stable-pool pricing** concentrates liquidity around the expected SOL/LST relationship.
+2. **Virtual price tracking** accounts for the LST's changing value over time.
+3. **Vault-backed liquidity** allows eligible idle assets to participate in Dynamic Vault yield where supported.
+
+The user experience stays simple. Users swap between SOL and the LST. LPs deposit liquidity and receive LP tokens. The pool handles the value adjustment internally.
+
+## Benefits for LPs
+
+DAMM v1 LST pools are designed to make LP participation more passive and more durable.
+
+LPs can benefit from:
+
+- **Lower-slippage routing volume** because stable-style liquidity is efficient near the expected exchange rate.
+- **Reduced LST appreciation mismatch** because the pool can account for the staking token's virtual price.
+- **Swap fee income** from users entering and exiting LST exposure.
+- **Additional vault yield** where eligible liquidity is routed through Dynamic Vaults.
+- **Farming rewards** if the LST protocol or partner funds a reward pool for LP tokens.
+
+## Benefits for LST protocols
+
+For an LST protocol, liquidity is distribution. A strong SOL/LST pool can make the token easier to buy, easier to exit, easier to integrate, and more attractive to DeFi users.
+
+DAMM v1 LST pools help protocols:
+
+- Build liquidity around the natural SOL/LST relationship.
+- Improve aggregator routing and execution quality.
+- Reduce dependence on short-term token emissions.
+- Offer LPs multiple potential return sources.
+- Support early liquidity growth while the LST is still building adoption.
+
+## Dynamic Vault yield for LST pools
+
+Some DAMM v1 LST pool assets can connect to Dynamic Vaults. When supported, idle SOL or stablecoin-side liquidity may be allocated into external lending strategies while the pool remains available for swaps and withdrawals.
+
+This matters because LST liquidity can be strategic and long-lived. Vault yield can help keep LPs engaged during periods when swap volume is not enough on its own.
+
+<Warning>
+  LST pools still carry risk. LPs should understand LST protocol risk, smart contract risk, liquidity risk, depeg risk, lending strategy risk, and the possibility that incentives change over time.
+</Warning>
+
+## When to use an LST pool
+
+A DAMM v1 LST pool is useful when:
+
+- The pair is SOL and a supported liquid staking token.
+- The LST has a reliable way to determine virtual price or staking value.
+- The goal is low-slippage routing, not wide price discovery.
+- The protocol wants passive liquidity that can remain productive over time.
+- LPs need more than short-term farming rewards to justify liquidity.
+
+For volatile token launches or pairs without a stable relationship, use a constant-product design instead.

--- a/legacy-products/damm-v1/pool-design-guide.mdx
+++ b/legacy-products/damm-v1/pool-design-guide.mdx
@@ -1,0 +1,180 @@
+---
+title: "DAMM v1 Pool Design Guide"
+sidebarTitle: "Pool Design Guide"
+description: "Choose the right DAMM v1 pool type, yield layers, farm setup, fee interpretation, and liquidity commitment for a legacy Meteora pool."
+llmsDescription: "Non-technical design guide for DAMM v1 pools, helping teams choose between constant-product, stable, and LST pools; decide whether to use farms, Dynamic Vault yield, liquidity locks, fee and APY metrics, and launch or maintenance considerations."
+---
+
+DAMM v1 is a legacy product, but many teams still need to understand how to evaluate or maintain an existing DAMM v1 pool. This guide helps you think like a product owner: what kind of market are you creating, what LP behavior do you want, and what return stack supports that behavior?
+
+## Step 1: Choose the pool curve
+
+### Use a constant-product pool for volatile markets
+
+Choose a constant-product DAMM v1 pool when the token pair needs open-ended price discovery.
+
+Good fit:
+
+- Project token paired with SOL or USDC.
+- Long-tail assets.
+- Markets where price can move significantly.
+- Liquidity that should cover a wide price range.
+
+Product tradeoff: liquidity is spread across the full curve, so it is simple and robust, but not as capital efficient around a narrow price band.
+
+### Use a stable pool for pegged or correlated assets
+
+Choose a stable pool when both assets should trade close to a target relationship.
+
+Good fit:
+
+- Stablecoin pairs.
+- Correlated assets.
+- Assets where low slippage near a peg is more important than wide price discovery.
+
+Product tradeoff: stable pools are efficient near the target relationship, but they are not designed for assets that can freely reprice against each other.
+
+### Use an LST pool for supported SOL/LST markets
+
+Choose an LST pool when one side is SOL and the other is a supported liquid staking token.
+
+Good fit:
+
+- LST protocols building liquidity.
+- SOL/LST swap routes.
+- Markets where the LST appreciates against SOL over time.
+
+Product tradeoff: LST pools improve the fit for staking-token markets, but teams still need to account for LST protocol risk and depeg risk.
+
+## Step 2: Understand the LP return stack
+
+DAMM v1 LP returns can come from several layers:
+
+<CardGroup cols={2}>
+  <Card title="Swap Fees" icon="percent" iconType="solid">
+    Organic trading demand pays fees that can increase the value backing LP tokens.
+  </Card>
+  <Card title="Dynamic Vault Yield" icon="vault" iconType="solid">
+    Eligible idle assets may earn external strategy yield through Dynamic Vaults.
+  </Card>
+  <Card title="Farm Rewards" icon="seedling" iconType="solid">
+    Partner-funded farms can distribute up to two reward tokens to staked LP tokens.
+  </Card>
+  <Card title="Liquidity Commitment" icon="lock" iconType="solid">
+    Locked LP tokens can signal long-term support and improve market confidence.
+  </Card>
+</CardGroup>
+
+A strong pool does not need every layer, but it should have a clear reason for why LPs will stay.
+
+## Step 3: Decide whether the pool needs a farm
+
+A farm is useful when organic fees and vault yield are not enough to attract the target depth.
+
+Use a farm when:
+
+- The market is new and needs bootstrapping.
+- The project wants to compete for aggregator routing.
+- A partner wants to reward LPs for supporting strategic liquidity.
+- The pool needs a campaign window around launch, migration, or growth.
+
+Avoid relying only on farms when:
+
+- The reward budget is too small to change LP behavior.
+- There is no plan for liquidity after incentives end.
+- The reward token is highly volatile and could distort displayed APR.
+- The pool has no expected trading demand.
+
+## Step 4: Evaluate Dynamic Vault fit
+
+Dynamic Vault yield is valuable when the pool contains supported assets such as major stablecoins or SOL. It is less relevant when a token side has no supported vault strategy.
+
+Ask:
+
+- Does one side or both sides of the pool have Dynamic Vault support?
+- How much of the return expectation comes from vault yield?
+- What external strategy risks does the vault introduce?
+- How important is immediate withdrawal liquidity for this LP audience?
+
+Vault yield is best used as a durability layer, not as the only reason to LP.
+
+## Step 5: Decide whether to lock liquidity
+
+Liquidity locks are useful when trust and continuity matter.
+
+Consider a lock when:
+
+- The project wants to demonstrate long-term liquidity commitment.
+- The pool is part of a token launch or migration.
+- Community members are concerned about sudden liquidity removal.
+- A partner or launchpad requires a visible commitment.
+
+A lock improves confidence, but it does not eliminate market risk. Locked LP tokens are still exposed to the pool's assets and the pool's underlying mechanics.
+
+## Step 6: Read APY as components, not one number
+
+When reviewing a DAMM v1 pool, split the displayed return into parts:
+
+- **Base APY** from virtual price growth.
+- **Fee-over-TVL** from recent trading fees.
+- **Vault yield** from eligible Dynamic Vault strategies.
+- **Farm APR** from reward emissions.
+
+This prevents a common mistake: treating a temporary farm APR as if it were permanent pool yield.
+
+## Step 7: Match the pool to the audience
+
+### Traders
+
+Traders care about execution quality: depth, slippage, reliability, and routing.
+
+### LPs
+
+LPs care about return, risk, ease of withdrawal, asset exposure, and incentive duration.
+
+### Projects
+
+Projects care about liquidity depth, market confidence, token distribution, and sustainability after campaigns end.
+
+### Integrators
+
+Integrators care about predictable pool behavior, existing liquidity, and whether the market is still maintained.
+
+A good DAMM v1 pool design aligns all four groups.
+
+## Recommended DAMM v1 patterns
+
+### Stablecoin pool
+
+- Use a stable pool.
+- Prioritize low slippage and routing volume.
+- Use Dynamic Vault yield where supported.
+- Add farms only when you need extra campaign depth.
+
+### SOL/LST pool
+
+- Use an LST-aware stable pool when supported.
+- Emphasize virtual price tracking and reduced staking-token mismatch.
+- Consider partner rewards during early liquidity growth.
+- Educate LPs on LST and depeg risk.
+
+### Long-tail token pool
+
+- Use a constant-product pool.
+- Consider a liquidity lock for trust.
+- Use farms for launch or migration windows.
+- Be realistic about organic volume after incentives end.
+
+## Final checklist
+
+Before promoting or maintaining a DAMM v1 pool, answer:
+
+- What curve does this market need: constant-product, stable, or LST?
+- What assets are in the pool, and what risks do they introduce?
+- Does the pool have eligible Dynamic Vault yield?
+- Is there an active farm, and when does it end?
+- How are fees and APY displayed to LPs?
+- Is any liquidity locked?
+- What is the plan after incentives decline?
+
+The best DAMM v1 pools are not just high-APR pools. They are pools with a clear market purpose, sustainable LP reasons, and transparent tradeoffs.

--- a/legacy-products/damm-v1/pools-with-farms.mdx
+++ b/legacy-products/damm-v1/pools-with-farms.mdx
@@ -1,46 +1,114 @@
 ---
-title: "Pools with Farms"
-description: "How farming works on DAMM v1 pools — LPs can stake their LP tokens to earn additional token rewards on top of swap fees and vault yield."
+title: "Pools With Farms"
+description: "Understand how DAMM v1 farms let LPs stake LP tokens to earn partner reward tokens on top of trading fees and eligible vault yield."
+llmsDescription: "Product documentation for DAMM v1 pools with farms, explaining LP-token staking, dual reward tokens, reward duration, reward rate, staking and claiming flow, APR display, campaign design, permissioned farm creation, and how farms complement fees and Dynamic Vault yield."
 ---
 
-Our farming program for Dynamic AMM (DAMM v1) Pools allows Liquidity Providers, who deposit in Meteora pools, to stake LP token to earn rewards.
+DAMM v1 pools can be paired with external farms. A farm lets LPs stake their DAMM v1 LP tokens and earn additional reward tokens funded by a project, partner, or campaign sponsor.
 
-Rewards come from partners with a maximum of 2 reward tokens for a farming pool.
+This gives teams a way to incentivize liquidity without changing the underlying AMM pool. The pool continues to support swaps and earn trading fees. The farm adds a separate reward layer on top.
 
-There can be multiple farming pools for a Meteora pool. Farmers should notice on APR and Expiration before staking LP token to a farming pool.
+## Why add a farm?
 
-Here are steps to integrate with the farming program:
+Liquidity is a marketplace. LPs compare expected return, token risk, depth, duration, and opportunity cost. A farm helps a project make its pool more attractive by adding explicit token incentives.
 
-<CardGroup cols={2}>
-  <Card title="Stake" icon="steak" iconType="solid">
-    Deposit into a Meteora pool to receive LP tokens, which represent your share in the pool. Then, stake your LP tokens in a farming pool to start earning rewards.
-  </Card>
-  <Card title="Claim" icon="gift" iconType="solid">
-    If you have staked LP tokens in a farming pool, you can claim up to two different reward tokens provided by the pool at any time.
-  </Card>
-  <Card title="Unstake" icon="unlock" iconType="solid">
-    To withdraw from a Meteora pool, first unstake your LP tokens from the farming pool. Once unstaked, you can withdraw your liquidity from the Meteora pool as usual.
-  </Card>
-</CardGroup>
+Farms are useful when a project wants to:
 
-# How do I create a new farm?
+- Bootstrap liquidity for a new or strategic market.
+- Retain LPs during an important launch or campaign window.
+- Compete for routing volume on aggregators.
+- Reward early liquidity supporters.
+- Add incentives while the pool's organic trading fee revenue is still growing.
 
-<Danger>Farms are permissioned.</Danger>
+## How DAMM v1 farms work
+
+The DAMM v1 farm model is simple:
 
 <Steps>
-  <Step title="Open a Discord Ticket">
-    Head to Meteora's [discord](https://discord.gg/meteora) and open a ticket.
+  <Step title="LP deposits into the DAMM v1 pool">
+    The LP adds liquidity to a DAMM v1 pool and receives LP tokens representing their pool share.
   </Step>
-  <Step title="Provide Pool Information">
-    Provide the following information:
-    - DAMM v1 pool address or Link to the pool you want to create a farm for
-    - Reward A token mint address 
-    - Reward B token mint address (optional)
-    - Reward Duration (in seconds) - We recommend 4 weeks
-    <Note>Whenever you add rewards it resets the farm duration.</Note>
-    <Warning>Once rewards are added into the farm, they cannot be removed.  Sometimes, at the end of the farm period, there could be spare rewards remaining due to 0 LP stakers in the farm during the farm period. These remaining rewards can be linearly distributed again if you extend the farm period.</Warning>
+  <Step title="LP stakes LP tokens in the farm">
+    The LP deposits those LP tokens into the farming program. While staked, the LP tokens earn rewards based on their share of total staked LP tokens.
   </Step>
-  <Step title="Seed the Pool with Rewards">
-    Head to our [rewards admin dashboard](https://meteora-admin.vercel.app/) to seed the pool with the rewards or seed the rewards via the [farming ts-sdk](/developer-guide/guides/damm-v1/farming-sdk/getting-started).
+  <Step title="Rewards accrue over time">
+    The farm distributes funded rewards linearly across the configured reward duration. DAMM v1 farms can support up to two reward tokens.
+  </Step>
+  <Step title="LP claims or unstakes">
+    The LP can claim earned rewards. To withdraw pool liquidity, the LP first unstakes LP tokens, then removes liquidity from the DAMM v1 pool.
   </Step>
 </Steps>
+
+## Reward distribution
+
+DAMM v1 farms distribute rewards based on staked LP token share.
+
+```math
+\text{reward rate} = \frac{\text{funded reward amount}}{\text{reward duration}}
+```
+
+```math
+\text{user reward} = \text{user staked share} \times \text{rewards emitted during the period}
+```
+
+If a user stakes 10% of all LP tokens in the farm, they earn roughly 10% of the emitted rewards during the period they remain staked, subject to exact on-chain accounting and timing.
+
+## What LPs can earn
+
+A DAMM v1 pool with a farm can have several return layers:
+
+- **Swap fees** from trading activity in the AMM pool.
+- **Dynamic Vault yield** if eligible pool assets are connected to Dynamic Vault strategies.
+- **Farm rewards** from the reward pool.
+- **Partner incentives** when a campaign adds additional reward sources.
+
+<Note>
+  Farming rewards are not the same as pool fees. LPs must stake their LP tokens in the farm to earn farm rewards. Holding LP tokens outside the farm still represents pool ownership, but it may not receive farming incentives.
+</Note>
+
+## Farm design choices
+
+A good farm campaign should answer five product questions:
+
+### What behavior are you incentivizing?
+
+Most farms incentivize liquidity depth. The project wants LPs to keep capital in the pool so traders get better execution.
+
+### Which reward token should be used?
+
+Reward tokens should be meaningful to the LP audience. Many campaigns use a project token, partner token, or strategic ecosystem incentive.
+
+### How long should rewards last?
+
+Short campaigns can bootstrap attention, but they may attract mercenary liquidity. Longer campaigns can support stability but require larger budgets. A common starting point is a multi-week campaign.
+
+### How much liquidity is needed?
+
+The reward budget should match the target pool depth. Overpaying can waste emissions. Underpaying may fail to move liquidity.
+
+### What happens when rewards end?
+
+A farm is healthiest when it bridges a pool toward organic sustainability: trading volume, vault yield, integrations, and stronger user demand.
+
+## Permissioned farm creation
+
+DAMM v1 farm creation is permissioned. If you need a farm for a DAMM v1 pool, prepare the following information before contacting Meteora:
+
+- DAMM v1 pool address or pool link.
+- Reward token A mint address.
+- Reward token B mint address, if using a second reward token.
+- Reward duration in seconds.
+- Intended campaign objective and expected start timing.
+
+<Warning>
+  Once rewards are funded into a farm, they should be treated as committed campaign budget. If a campaign is extended, remaining rewards can be rolled into the new rate, but teams should plan funding carefully before launch.
+</Warning>
+
+## Farms vs Dynamic Vault yield
+
+Farms and Dynamic Vault yield solve different problems.
+
+- **Farms** are explicit incentives funded by a project or partner. They are great for targeted campaigns but depend on a finite reward budget.
+- **Dynamic Vault yield** comes from eligible idle liquidity being allocated to external strategies. It can support a pool's baseline return profile but depends on available lending yield and strategy risk.
+
+The strongest DAMM v1 pools often combine both: vault yield for ongoing capital productivity, farms for strategic growth moments, and swap fees for organic demand.

--- a/legacy-products/damm-v1/stable-pools.mdx
+++ b/legacy-products/damm-v1/stable-pools.mdx
@@ -1,26 +1,87 @@
 ---
 title: "Stable Pools"
-description: "DAMM v1 stable pools use a StableSwap invariant optimized for pegged assets (stablecoins, LSTs), offering lower slippage than constant-product pools."
+description: "Understand DAMM v1 stable pools, the StableSwap-style design used for pegged assets, and why amplification helps create lower-slippage liquidity around a target price."
+llmsDescription: "Product documentation for DAMM v1 stable pools, explaining StableSwap curves, amplification, token normalization, supported use cases such as stablecoins and correlated assets, LP benefits, risks, and how stable pools differ from constant-product pools."
 ---
 
-# How do DAMM v1 Stable Pools work?
+DAMM v1 stable pools are designed for token pairs that are expected to trade close to a known relationship. The common examples are stablecoin pairs such as USDC/USDT, but the same product idea can apply to other correlated assets.
 
-Meteora's Dynamic AMM Stable Pools are AMMs utilizing the stable curve that support token prices from 0 to infinity.
+Instead of spreading liquidity evenly across every possible price like a volatile constant-product pool, a stable pool concentrates more of its effective liquidity near the target relationship. The result is a smoother trading experience for assets that should not move far apart.
 
-Stable Pools are suitable if both of your tokens are stable coins i.e. USDC-USDT, USDS-USDC. Using a Stable Pool helps ensure that the liquidity ratio between the token pair remains at 1:1.
+## What stable pools are best for
 
-Stable Pools also share similar benefits with the volatile Dynamic AMM Pools. For example, Stable Pools compose on top of [Dynamic Vaults](/overview/other-products/dynamic-vault/what-is-dynamic-vault) lending aggregator that rebalances funds (e.g. USDC/USDT/SOL) every minute across various external lending protocols e.g. Kamino, Save (Solend), and Marginfi to optimize yield and reduce risk. 
+Use a DAMM v1 stable pool when the pair has a strong reason to trade close together:
 
-This added yield helps drive sustainable liquidity, as it is attractive for LPs to contribute liquidity in the pool even if trading fees are lower than usual or there is a lack of LM rewards.
+- **Stablecoin pairs** such as USDC/USDT or other dollar-denominated assets.
+- **Closely correlated assets** where traders expect a tight exchange rate.
+- **Yield-bearing or receipt-style assets** when the pool can account for their value relationship.
+- **High-volume routing pairs** where low slippage matters more than supporting a wide speculative price range.
 
-- Dynamic Stable Pools are concentrated, so they capture a lot more trading volume and fees.
+A stable pool is not the right fit for a volatile token launch or a pair where the price can move freely. For those markets, a constant-product pool is usually more appropriate.
 
-- Dynamic Stable Pools earn from lending the idle liquidity out to external lending protocols. 
+## How stable pools work
 
-- Dynamic Stable Pools do not require active LP management. You can set and forget it.
+DAMM v1 stable pools use a StableSwap-style curve. Product-wise, the curve has two behaviors:
 
-<Note>Dynamic Stable Pools have the Stable tag on the UI.</Note>
+- Near the expected relationship, it behaves like the pool has deeper liquidity, so trades can happen with lower slippage.
+- Far away from the expected relationship, it becomes more expensive to push the pool further out of balance.
 
-# What is AMP in a DAMM v1 Stable Pool?
+This creates a natural incentive for the pool to support efficient swaps near the target while still protecting LPs when one side becomes scarce.
 
-The AMP (amplification) factor controls how concentrated the liquidity is in the stable pool, which relates to how far the ratio of 1:1 the assets will go before it starts to charge more for trades that further unbalance the ratio and charge less for trades that move the ratio of assets back to 1:1.
+## The role of amplification
+
+The amplification factor, often called `AMP`, controls how concentrated the pool's liquidity feels around the target relationship.
+
+- **Higher AMP** means tighter pricing and lower slippage near the target.
+- **Lower AMP** means the pool behaves more like a normal AMM and is more tolerant of imbalance.
+
+<Note>
+  In DAMM v1 permissionless stable pools, the program uses a standard amplification setting. More specialized configurations may use permissioned pool setup.
+</Note>
+
+Think of AMP as the pool's confidence in the relationship between the two assets. If the assets are genuinely stable relative to each other, more amplification can improve the trading experience. If the relationship is uncertain, too much amplification can make the pool brittle when the pair moves away from the target.
+
+## Why stable pools help LPs
+
+Stable pools are built to make LP capital more productive around the prices where trades are expected to happen.
+
+For LPs, that can mean:
+
+- More efficient use of liquidity around the target relationship.
+- Better volume capture from routers and aggregators looking for low-slippage paths.
+- Less need for active position management compared with concentrated liquidity systems.
+- Additional potential yield when eligible assets are connected to Dynamic Vaults.
+
+DAMM v1 stable pools are still passive LP positions. LPs deposit assets, receive LP tokens, and hold a share of the pool. They do not need to manually rebalance a custom price range.
+
+## Dynamic Vault composition
+
+Stable pools can compose with Dynamic Vaults when the assets are supported by the vault layer. That means some idle pool liquidity can be allocated into external lending strategies while the pool continues serving swaps and withdrawals.
+
+This matters because stable pairs can sometimes have lower trading fees than volatile pairs. Vault yield can help improve the LP return profile during quieter trading periods.
+
+<Warning>
+  Dynamic Vault yield is an additional source of return, not a guarantee. Lending strategies introduce their own risks, and pool liquidity must still support withdrawals and swaps.
+</Warning>
+
+## Stable pools vs constant-product pools
+
+Choose a **stable pool** when:
+
+- The assets should trade close to a target value.
+- Low slippage near the peg is the main goal.
+- LPs want passive liquidity without setting active ranges.
+- The market is more about efficient routing than price discovery.
+
+Choose a **constant-product pool** when:
+
+- The assets can move significantly against each other.
+- The market needs full-range price discovery.
+- The pair includes a volatile token.
+- You do not want the pool optimized around a specific relationship.
+
+## Example: stablecoin liquidity
+
+Suppose a USDC/USDT pool has deep liquidity and both tokens are expected to trade close to $1. A stable pool can offer tight pricing for users swapping between the two assets. Traders get lower slippage, aggregators can route more volume through the pool, and LPs earn fees from that activity.
+
+If the pool's assets are supported by Dynamic Vaults, idle liquidity may also earn additional lending yield, improving the pool's appeal even when swap volume fluctuates.

--- a/legacy-products/damm-v1/what-is-damm-v1.mdx
+++ b/legacy-products/damm-v1/what-is-damm-v1.mdx
@@ -1,35 +1,106 @@
 ---
-title: "What's DAMM v1?"
-description: "DAMM v1 is Meteora's constant-product AMM (x·y=k) that earns LPs both swap fees and additional yield from idle liquidity deployed to lending protocols via Dynamic Vaults."
+title: "What is DAMM v1?"
+sidebarTitle: "What is DAMM v1?"
+description: "Learn how Meteora DAMM v1 combines full-range AMM liquidity, stable pools, LST pools, farms, liquidity locks, and Dynamic Vault yield into one legacy liquidity product."
+llmsDescription: "Product overview of Meteora DAMM v1, explaining the Dynamic AMM as a legacy Solana AMM built on constant-product and stable-swap curves, with vault-backed liquidity, LP tokens, farming rewards, Dynamic Vault yield, LST support, stable pools, protocol and partner fees, launch activation controls, and liquidity locks."
 ---
 
-Meteora's Dynamic AMM Pools are similar to constant product pools that support token prices from 0 to infinity. LPs on Dynamic AMM Pools earn both swap fees and yield from lending platforms.
+DAMM v1 is Meteora's original Dynamic AMM on Solana. It is a legacy liquidity product for teams and liquidity providers that want simple, full-range market making with extra yield layers built around the pool.
 
-The price of your token in a Dynamic AMM (Volatile) Pool is based on the formula: 
-```math
-x*y = k
-```
+At the surface, a DAMM v1 pool feels familiar: two tokens, shared liquidity, LP tokens, swaps, trading fees, and pool ownership represented by LP shares. Under the hood, DAMM v1 routes each side of the pool through Meteora's Dynamic Vault infrastructure, so eligible assets can earn external lending yield while still supporting swaps and withdrawals.
 
-- x and y are the quantities of the two tokens in the pool (e.g. MET and USDC).
-- k is a constant. As trades occur, the product of the amounts of the two tokens must remain the same.
-- If someone buys MET with USDC from your pool, the amount of MET in your pool decreases, and the amount of USDC increases. The DAMM v1 Pool adjusts the price based on the new token balances in the pool.
+<Info>
+  DAMM v1 runs on the mainnet program `Eo7WjKq67rjJQSZxS6z3YkapzY3eMj6Xy8X5EQVn5UaB`.
+</Info>
 
-# Earn additional yield by utilizing lending sources
+## Why DAMM v1 matters
 
-DAMM v1 Pools have a unique yield infrastructure where pools are built on top of the capital allocation layer.
+DAMM v1 was built for a simple problem: liquidity is expensive to attract and even more expensive to keep.
 
-To the user, DAMM v1 Pools look similar to standard AMMs that uses the proven SPL-token swap. But underneath the hood, assets in the pools will be deposited directly into the Dynamic Vaults in the yield layer and USDC/SOL/USDT tokens get dynamically allocated to external lending protocols to generate yield and rewards, reducing the reliance on liquidity mining to attract liquidity.
+Traditional AMMs usually rely on two sources of LP return: swap fees and token incentives. That can work during periods of high volume or large farming campaigns, but it often becomes fragile when trading slows down or rewards end. DAMM v1 adds a third source of return by connecting idle eligible assets to Dynamic Vaults, helping LPs earn additional yield without actively moving capital themselves.
 
-Overreliance on liquidity mining to attract LPs is unsustainable and can cause issues such as token inflation and short-term liquidity when LPs lose interest after the rewards end. Our Dynamic AMM Pools avoid this through effective capital allocation mechanisms of the idle assets to earn yield for the LPs.
+That makes DAMM v1 especially useful for:
 
-This allows LPs to receive yield from a few different places — the lending interest, the liquidity mining rewards collected from the platforms, the AMM trading fees, and Meteora liquidity mining rewards (when available).
+- **Long-tail token markets** that need dependable full-range liquidity.
+- **Stable asset pairs** that need low-slippage swaps near a target peg.
+- **LST markets** where the staking token appreciates against SOL over time.
+- **Partner-incentivized pools** where projects want to add farms on top of AMM fees.
+- **Community confidence pools** where teams want to lock liquidity while fees continue to accrue.
 
-# Permanently lock liquidity and claim fees from locked liquidity
+## Product pillars
 
-Moreover, LPs can choose to permanently lock their liquidity on Dynamic AMM Pool to raise community confidence, while continuing to earn and claim fees from this locked liquidity.
+<CardGroup cols={2}>
+  <Card title="Full-Range AMM Liquidity" icon="infinity" iconType="solid">
+    DAMM v1 supports classic full-range AMM liquidity for assets that can trade across a wide price range.
+  </Card>
+  <Card title="Stable Pools" icon="scale-balanced" iconType="solid">
+    Stable pools use a StableSwap-style curve to create deeper liquidity around assets expected to trade close to each other.
+  </Card>
+  <Card title="LST Pools" icon="leaf" iconType="solid">
+    LST pools account for staking-token appreciation by using a depeg-aware stable pool design for SOL/LST pairs.
+  </Card>
+  <Card title="Dynamic Vault Yield" icon="vault" iconType="solid">
+    Eligible pool assets can sit inside Dynamic Vaults, where idle liquidity may be allocated to supported lending strategies.
+  </Card>
+  <Card title="Pools With Farms" icon="seedling" iconType="solid">
+    Projects can add external farming rewards so LPs earn incentive tokens on top of pool fees and eligible vault yield.
+  </Card>
+  <Card title="Liquidity Locks" icon="lock" iconType="solid">
+    LP tokens can be locked to signal long-term commitment while the locked liquidity remains part of the pool.
+  </Card>
+</CardGroup>
 
-This helps to create a more sustainable and long-term liquidity provision for the ecosystem that prioritizes value creation and attracts committed LPs.
+## How DAMM v1 works
 
-To cater to memecoin launches, Memecoin Pools (a subset of Dynamic AMM Pools) have a dynamic fee, which ranges from 0.15%-15% and is set by the protocol. This fee may be changed by the protocol over time to optimize for different launches and market conditions. Memecoin Pool LPs also earn lending yield from the locked SOL and USDC liquidity in the pool.
+A DAMM v1 pool has two token sides: token A and token B. When LPs deposit both assets, they receive LP tokens that represent their share of the pool. Traders swap against the pool, and the pool updates its reserves according to the curve selected for that market.
 
-**Additional info:** Compare between DLMM, DAMM v1, and DAMM v2 [here](https://docs.google.com/spreadsheets/d/1-W2KE2PT18lmWKF6kB-7aolUBk2e5QvETL3D7g3F_VE/edit?usp=sharing).
+DAMM v1 supports two major curve families:
+
+- **Constant-product pools** use the familiar `x × y = k` model. They are best for volatile assets where the price can move freely across a wide range.
+- **Stable pools** use an amplified StableSwap curve. They are best for assets that should trade close together, such as stablecoins or certain SOL/LST pairs.
+
+The pool itself does not simply hold raw token balances. Each side points to a Dynamic Vault. The DAMM v1 program tracks the pool's vault LP position and converts it back into total token value when swaps, deposits, withdrawals, and locks happen. This is why a DAMM v1 LP can earn from more than one source: swap activity can increase pool value, and eligible vault assets can earn external yield.
+
+## LP return stack
+
+DAMM v1 LPs can earn from multiple layers depending on the pool configuration:
+
+1. **Trading fees** from swaps through the pool.
+2. **Dynamic Vault yield** when eligible assets such as USDC, USDT, or SOL are routed through supported vault strategies.
+3. **Farming rewards** when a project or partner funds an external reward pool for DAMM v1 LP tokens.
+4. **Partner or campaign incentives** when additional programs route incentives to the pool.
+
+<Note>
+  Not every DAMM v1 pool has every yield source. A volatile pool without a farm is different from a stable pool with Dynamic Vault yield and partner incentives. Always evaluate the specific pool's fee, farm, vault, and risk profile.
+</Note>
+
+## DAMM v1 vs DAMM v2
+
+DAMM v1 is a legacy product. It remains important because many pools and integrations were built around its LP-token model, Dynamic Vault composition, stable pool design, and farming program.
+
+DAMM v2 is the newer configurable AMM. It adds modern product controls such as NFT positions, concentrated liquidity options, launch-ready fee modes, built-in liquidity mining, Token 2022 support, and more granular pool configuration.
+
+Use DAMM v1 documentation when you are trying to understand existing legacy pools, stable pools, LST pools, old farm structures, or vault-backed liquidity behavior. Use DAMM v2 documentation when you are designing a new pool that needs the latest Meteora product surface.
+
+## Explore DAMM v1
+
+<CardGroup cols={2}>
+  <Card title="DAMM v1 Formulas" href="/legacy-products/damm-v1/damm-v1-formulas" icon="calculator">
+    Understand constant-product pricing, StableSwap behavior, LP share value, fees, and rewards in plain English.
+  </Card>
+  <Card title="Stable Pools" href="/legacy-products/damm-v1/stable-pools" icon="scale-balanced">
+    Learn why stable pools are optimized for assets that should trade close to a target price.
+  </Card>
+  <Card title="LST Pools" href="/legacy-products/damm-v1/lst-pools" icon="leaf">
+    See how DAMM v1 supports SOL/LST liquidity while accounting for staking-token appreciation.
+  </Card>
+  <Card title="Pools With Farms" href="/legacy-products/damm-v1/pools-with-farms" icon="seedling">
+    Learn how external reward pools add token incentives for LPs.
+  </Card>
+  <Card title="Dynamic Vault Yield" href="/legacy-products/damm-v1/additional-yield-from-dynamic-vaults" icon="vault">
+    Understand how eligible idle liquidity can earn additional lending yield.
+  </Card>
+  <Card title="Pool Design Guide" href="/legacy-products/damm-v1/pool-design-guide" icon="sliders">
+    Choose the right DAMM v1 pool type, fee setup, reward design, and LP experience.
+  </Card>
+</CardGroup>

--- a/user-guides/becoming-a-liquidity-provider.mdx
+++ b/user-guides/becoming-a-liquidity-provider.mdx
@@ -83,7 +83,7 @@ Creating a new dynamic pool is permissionless, meaning any user or developer can
 
 In addition, with DAMM v1 pools, [memecoin creators have the option to "burn" their liquidity](https://x.com/MeteoraAG/status/1786045723953557507) by permanently locking the Meteora LP tokens (which represent the liquidity in a dynamic pool). Memecoin creators can compound and claim fees on permanently locked liquidity forever, even though they no longer have access to that liquidity. Memecoin creators can consider launching their memecoin with a Memecoin Pool, which is a subset of dynamic pools and has features specially catered to memecoin launches (e.g. a dynamic fee % schedule).
 
-Read an overview of DAMM v1 [here](/overview/products/damm-v1/what-is-damm-v1#whats-damm-v1). Any user can create a new DAMM v1 pool [here](https://app.meteora.ag/create). 
+Read an overview of DAMM v1 [here](/legacy-products/damm-v1/what-is-damm-v1). Any user can create a new DAMM v1 pool [here](https://app.meteora.ag/create).
 
 ### DAMM v2
 


### PR DESCRIPTION
## Summary
- Rewrites DAMM v1 legacy product docs with product-focused explanations grounded in the on-chain program
- Adds Liquidity Locks and Pool Design Guide pages
- Expands formulas, stable pools, LST pools, farms, Dynamic Vault yield, and fee/APY docs
- Updates DAMM v1 navigation and stale DAMM v1 links to the v3 docs routes

## Test Plan
- git diff --check
- python3 -m json.tool docs.json >/tmp/docs-json-ok
- DAMM v1 MDX sanity check for frontmatter and balanced Mintlify components
- npx -y mintlify@latest broken-links (repo has pre-existing broken links; no DAMM v1 section broken links from this change)